### PR TITLE
Allow selecting the gradient transition color in CTA section

### DIFF
--- a/assets/call-to-action.css
+++ b/assets/call-to-action.css
@@ -44,14 +44,14 @@
   background: var(--background-primary);
 }
 
-.cta__vision--overlay:after {
+.cta__vision--transition:after {
   content: "";
   position: absolute;
   left: 0;
   top: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(180deg, var(--background-primary) 11.17%, var(--background-primary-00) 41.57%),
+  background: linear-gradient(180deg, var(--color-transition) 11.17%, var(--color-transition-00) 41.57%),
               linear-gradient(349deg, var(--color-primary-30) 43.3%, var(--color-primary-00) 80.3%);
 }
 

--- a/sections/articles.liquid
+++ b/sections/articles.liquid
@@ -99,7 +99,7 @@
                   image: image,
                   loading: 'lazy',
                   class: 'articles__image',
-                  size: 'm'
+                  size: 'l'
                 -%}
               {%- endif -%}
             </div>

--- a/sections/call-to-action.liquid
+++ b/sections/call-to-action.liquid
@@ -11,13 +11,13 @@
 {%- assign button_label          = section.settings.button_label -%}
 {%- assign button_url            = section.settings.button_url -%}
 {%- assign show_transition       = section.settings.show_transition -%}
-{%- assign transtion_color       = section.settings.transtion_color -%}
+{%- assign transition_color      = section.settings.transition_color -%}
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
   {%- if show_transition -%}
-    --color-transition: {{- transtion_color -}};
-    --color-transition-00: {{- transtion_color | append: "00" -}};
+    --color-transition: {{- transition_color -}};
+    --color-transition-00: {{- transition_color | append: "00" -}};
   {%- endif -%}
 
   {%- case padding_top -%}
@@ -138,7 +138,7 @@
       },
       {
         "type": "color",
-        "id": "transtion_color",
+        "id": "transition_color",
         "label": "Transition color",
         "default": "#1A3333"
       },

--- a/sections/call-to-action.liquid
+++ b/sections/call-to-action.liquid
@@ -10,10 +10,16 @@
 {%- assign image                 = section.settings.image -%}
 {%- assign button_label          = section.settings.button_label -%}
 {%- assign button_url            = section.settings.button_url -%}
-{%- assign show_overlay          = section.settings.show_overlay -%}
+{%- assign show_transition       = section.settings.show_transition -%}
+{%- assign transtion_color       = section.settings.transtion_color -%}
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
+  {%- if show_transition -%}
+    --color-transition: {{- transtion_color -}};
+    --color-transition-00: {{- transtion_color | append: "00" -}};
+  {%- endif -%}
+
   {%- case padding_top -%}
     {%- when 'small' -%}
       --padding-top: 60px;
@@ -76,7 +82,7 @@
     </div>
 
     {%- if image != blank -%}
-      <div class="cta__vision{% if show_overlay %} cta__vision--overlay{%- endif -%}">
+      <div class="cta__vision{% if show_transition %} cta__vision--transition{%- endif -%}">
         {%- render 'image',
           image: image,
           loading: 'lazy',
@@ -126,9 +132,15 @@
       },
       {
         "type": "checkbox",
-        "id": "show_overlay",
-        "label": "Show overlay",
+        "id": "show_transition",
+        "label": "Show transition",
         "default": true
+      },
+      {
+        "type": "color",
+        "id": "transtion_color",
+        "label": "Transition color",
+        "default": "#1A3333"
       },
       {
         "type": "header",

--- a/templates/index.json
+++ b/templates/index.json
@@ -43,7 +43,8 @@
         "padding_bottom_mobile": "large",
         "padding_top": "large",
         "padding_top_mobile": "large",
-        "show_overlay": false,
+        "show_transtion": false,
+        "transtion_color": "#FFFFFF",
         "tag": "HIGHLIGHT",
         "title": "Explore the ride <br> of your life"
       },

--- a/templates/index.json
+++ b/templates/index.json
@@ -43,8 +43,8 @@
         "padding_bottom_mobile": "large",
         "padding_top": "large",
         "padding_top_mobile": "large",
-        "show_transtion": false,
-        "transtion_color": "#FFFFFF",
+        "show_transition": false,
+        "transition_color": "#FFFFFF",
         "tag": "HIGHLIGHT",
         "title": "Explore the ride <br> of your life"
       },


### PR DESCRIPTION
The CTA section currently supports the `Show overlay` feature. This is good but there is a problem.

The gradient color currently depends on the selected color scheme - which makes sense. However, the gradient should start from the color of the section before it.

So the simplest solution for this is to add a new setting to specify the color of the overlay independently from the color scheme.

So should be done:

- Rename `Show overlay` to `Show transition`
- Add the `Transition color` option that decides from which color the transition starts

![Screenshot 2024-02-06 at 16 15 51](https://github.com/booqable/impact-theme/assets/40244261/41589e97-9ee1-4922-9b65-942375d29ada)
