### PR TITLE
Date picker is visible by default in the header

### DIFF
--- a/assets/header.css
+++ b/assets/header.css
@@ -86,7 +86,7 @@
 .header__date-picker-wrapper {
   grid-area: column-2;
   position: absolute;
-  top: calc(100% + 16px);
+  top: calc(100% + 8px);
   left: 50%;
   width: calc(100vw - var(--horizontal-padding-mobile, 16px) * 2);
   transform: translate(-50%, 0);
@@ -395,6 +395,7 @@ body:has(#mobile-menu-opener:checked) .header-transparent .header__logo-inner:no
     width: auto;
     transform: translate(0, 0);
     padding: 0 10px;
+    margin: calc(-1 * var(--padding-top)) 0 calc(-1 * var(--padding-bottom));
     z-index: 0;
   }
 }

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -104,7 +104,7 @@
           "padding_bottom_mobile": "medium",
           "search_placeholder": "Where are you looking for?",
           "signup_placeholder": "",
-          "show_datepicker": false,
+          "show_datepicker": true,
           "show_payments": false,
           "show_payments_mobile": true,
           "show_search": true,

--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -57,7 +57,7 @@
     {%- when 'medium' -%}
       --padding-top-mobile: 50px;
     {%- when 'large' -%}
-      --padding-top-mobile: 80px;
+      --padding-top-mobile: 100px;
   {%- endcase -%}
 
   {%- case padding_bottom_mobile -%}
@@ -66,7 +66,7 @@
     {%- when 'medium' -%}
       --padding-bottom-mobile: 50px;
     {%- when 'large' -%}
-      --padding-bottom-mobile: 80px;
+      --padding-bottom-mobile: 100px;
   {%- endcase -%}
 
   {%- case text_position -%}


### PR DESCRIPTION
The PR purpose is to make the period picker visible in the header. 
Essentially the period picker and its styles had already been added inside the header earlier but still, it was hidden. So now it is visible by default.

Also, just made some changes with indents to fit to header and not break or stretch it.
I'd say the component is looking not bad in a clean state on all resolutions but after a date was chosen the period picker breaks into 2(4) lines, especially it's a big problem for small screen devices. 

So still needs to be adjusted on the back-office side to make it prettier.

![Google Chrome_2024-02-09 15-10-09@2x](https://github.com/booqable/impact-theme/assets/40244261/a11965f4-0331-48b6-9249-d7fa7056a31b)
![Google Chrome_2024-02-09 15-09-49@2x](https://github.com/booqable/impact-theme/assets/40244261/f6ecb35e-3fa7-4f95-a801-a39573a78a4d)
![Google Chrome_2024-02-09 15-11-09@2x](https://github.com/booqable/impact-theme/assets/40244261/d82fd82d-2c3c-4dc6-9b87-f91daf91e9fa)
![Google Chrome_2024-02-09 15-11-28@2x](https://github.com/booqable/impact-theme/assets/40244261/bb848969-e8df-438f-9bd4-d43e7ff2dca0)
![Google Chrome_2024-02-09 15-11-43@2x](https://github.com/booqable/impact-theme/assets/40244261/5a9b29dc-f5be-4ad1-9c11-98493d5d4325)
