### PR TITLE
Colors corrections

### DIFF
--- a/assets/articles.css
+++ b/assets/articles.css
@@ -1,6 +1,6 @@
 .articles__wrapper {
-  color: var(--color-primary);
-  background: var(--background-primary);
+  color: var(--color-accent);
+  background: var(--background-accent);
 }
 
 .articles > .articles__container {
@@ -32,6 +32,10 @@
   scrollbar-color: transparent transparent;
 }
 
+.articles__title {
+  color: inherit;
+}
+
 .articles__item {
   overflow: hidden;
   min-width: 358px;
@@ -40,8 +44,8 @@
   grid-template-rows: max-content 1fr;
   scroll-snap-align: start;
   scroll-snap-stop: always;
-  color: var(--background-primary);
-  background: var(--color-primary);
+  background: var(--background-primary);
+  color: var(--color-primary);
   border-radius: var(--border-radius-rounded-blocks);
 }
 
@@ -85,12 +89,12 @@
   margin: 0 0 8px;
   font-family: var(--font-body, sans-serif);
   font-size: calc(var(--font-size-tagline) - 4px);
+  color: var(--color-secondary);
 }
 
 .articles__heading {
   font-weight: var(--font-weight-bold);
   margin-bottom: 16px;
-  color: var(--background-primary);
 }
 
 .articles__buttons {
@@ -102,11 +106,6 @@
 
 .articles__button.button {
   margin: 0;
-  color: var(--background-primary);
-}
-
-.articles__button.button path {
-  fill: var(--background-primary);
 }
 
 .articles__image {
@@ -116,8 +115,9 @@
   max-width: none;
 }
 
-.articles__show-button {
+.articles__show-button.button {
   margin: 0;
+  border-color: currentColor;
 }
 
 .articles__show-wrapper {

--- a/sections/articles.liquid
+++ b/sections/articles.liquid
@@ -139,7 +139,7 @@
 
                     {%- if article_btn != blank and article_btn_url != blank -%}
                       <div class="articles__buttons">
-                        <a href="{{ article_btn_url }}" class="articles__button button button--primary button--large">
+                        <a href="{{ article_btn_url }}" class="articles__button button button--outlined button--large">
                           {{- article_btn -}}
                         </a>
                       </div>


### PR DESCRIPTION
The PR's goal is to reconsider colors for the `Articles` section and use them for their direct assignment because currently, `background color` is used as a color of text, and `text color` is used as a background so that is confused

![Arc_2024-03-08 18-20-10@2x](https://github.com/booqable/impact-theme/assets/40244261/3a7a751e-030e-43f8-80a1-9347c0c10786)
