### PR TITLE
Added keep_type key to logo for transparent header

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -116,7 +116,8 @@
             class: 'header__logo-image',
             custom_width: '170',
             custom_size: '170px',
-            custom_alt: shop.name
+            custom_alt: shop.name,
+            keep_type: true
         -%}
       </span>
     {%- endif -%}


### PR DESCRIPTION
Make sure that we don't convert the format of the logo. This enables customers to use .png images that are sharper than the webp to which we convert by default. 
This feature is already used for main logos of the Header and the Footer but still missing for logo if the Header has no background