### PR TITLE
Top bar settings order

### DIFF
--- a/sections/top-bar.liquid
+++ b/sections/top-bar.liquid
@@ -124,6 +124,10 @@
         "default": "Free shipping from €50"
       },
       {
+        "type": "header",
+        "content": "Desktop settings"
+      },
+      {
         "type": "select",
         "id": "icon",
         "label": "Icon",
@@ -202,10 +206,6 @@
           }
         ],
         "default": "outline"
-      },
-      {
-        "type": "header",
-        "content": "Desktop settings"
       },
       {
         "type": "contentEditor",


### PR DESCRIPTION
In the Top bar settings in theme builder sidebar, the icon select menu should be placed in the `Desktop settings` section above the `Secondary message`.

Before:
![Arc_2024-04-11 11-27-58@2x](https://github.com/booqable/impact-theme/assets/40244261/910daf4b-923a-4fc2-9b15-7d34a02ecbc3)


After:
![Arc_2024-04-11 11-29-02@2x](https://github.com/booqable/impact-theme/assets/40244261/103df257-4b98-4b61-b5fc-d3ebd955b1d1)

