### PR TITLE
`Add to cart` button is broken when `Go to checkout` is enabled

### DIFF
--- a/sections/product-page.liquid
+++ b/sections/product-page.liquid
@@ -26,6 +26,7 @@
 {%- assign bundle_items          = product | bundle_items -%}
 {%- assign quantity              = product | product_button -%}
 {%- assign price                 = product | product_price -%}
+{%- assign period                = product | product_price_label -%}
 
 {%- assign label = "" -%}
 
@@ -153,7 +154,10 @@
 
       <div class="product-main__info">
         <h1 class="product-main__title">{{- title -}}</h1>
-        <div class="product-main__price">{{- price -}}</div>
+
+        {%- if price and period -%}
+          <div class="product-main__price">{{- price -}}</div>
+        {%- endif -%}
 
         {%- if description != blank -%}
           <div class="product-main__description bq-content rx-content">{{- description -}}</div>


### PR DESCRIPTION
For some reason there is an error in the browser console after trying to add something to the cart if `Go to checkout` option is enabled.

![Screenshot 2024-04-16 at 13 25 03](https://github.com/booqable/impact-theme/assets/40244261/ab8b338b-48f0-4a85-8099-2cf279a51186)


The Chameleon theme doesn't have such an issue but the Impact has and the only difference between them is that the Impact doesn't have `ProductPrice label`, so there is an assumption that it may caused by the dependency between the `Product button` and `ProductPrice label` components because that label is not used in Impact theme but could load some data in the ORM which `Product button` depends on.

