### PR TITLE
Remove `Product button label` due to it is not used anywhere

### DIFF
--- a/sections/product-page.liquid
+++ b/sections/product-page.liquid
@@ -26,7 +26,6 @@
 {%- assign bundle_items          = product | bundle_items -%}
 {%- assign quantity              = product | product_button -%}
 {%- assign price                 = product | product_price -%}
-{%- assign period                = product | product_price_label -%}
 
 {%- assign label = "" -%}
 
@@ -154,10 +153,7 @@
 
       <div class="product-main__info">
         <h1 class="product-main__title">{{- title -}}</h1>
-
-        {%- if price and period -%}
-          <div class="product-main__price">{{- price -}}</div>
-        {%- endif -%}
+        <div class="product-main__price">{{- price -}}</div>
 
         {%- if description != blank -%}
           <div class="product-main__description bq-content rx-content">{{- description -}}</div>


### PR DESCRIPTION
Those changes don't make any sense, the error is still reproduced. 
And it is caused because we don't use the `Product gallery` component in Impact theme but it loads some data that is needed for `Product button` correct work.
So the issue should be fixed on web components side