### PR TITLE
Fix search error in website's preview mode

### DIFF
--- a/assets/search.js
+++ b/assets/search.js
@@ -4,9 +4,14 @@ class Search {
 
     this.selector = {
       search: ".header__search",
+      searchForm: "#search",
       searchOpener: "#search-opener",
       searchInput: ".header__search-input",
       searchReset: ".header__search-reset"
+    }
+
+    this.attr = {
+      action: "action"
     }
 
     this.params = {
@@ -24,6 +29,7 @@ class Search {
   }
 
   elements() {
+    this.searchForm = this.search.querySelector(this.selector.searchForm);
     this.searchOpener = this.search.querySelector(this.selector.searchOpener);
     this.searchInput = this.search.querySelector(this.selector.searchInput);
     this.searchReset = this.search.querySelector(this.selector.searchReset);
@@ -35,6 +41,7 @@ class Search {
     document.addEventListener("click", this.searchOpen.bind(this));
     document.addEventListener("click", this.searchClear.bind(this));
     document.addEventListener("click", this.searchClose.bind(this));
+    document.addEventListener("submit", this.searchHandleSubmit.bind(this));
   }
 
   // set focus to the input field when opening the search popup
@@ -73,6 +80,22 @@ class Search {
     if (!query) return false;
 
     this.searchInput.value = query;
+  }
+
+  searchHandleSubmit (e) {
+    const target = e.target;
+
+    if (target !== this.searchForm) return false;
+
+    e.preventDefault();
+
+    const value = this.searchInput.value,
+          route = this.searchForm.getAttribute(this.attr.action);
+
+    this.url.href = this.url.origin + route;
+    this.url.searchParams.set(this.params.q, value);
+
+    window.location.href = this.url.href;
   }
 }
 


### PR DESCRIPTION
There's a problem in the Preview mode. In this mode, the search bar always shows "HTTP ERROR 404" page, even if you search for an existing product.
The problem is the URL after searching for an item.
It is redirecting to `/search?q=test` but this doesn't work with the Preview mode, it should be `/search?theme_id='here the theme id'&q'here what you're searching'`.
It was fixed in the Chameleon theme recently and this fix should be shared with Impact as well

The PR's goal is to add a lost `theme_id` parameter to URL which is required for correct search work in the Preview mode

Before:

![image (16)](https://github.com/booqable/impact-theme/assets/40244261/b823b16e-e7fc-4900-b832-4d903e778195)


After:

![Arc_2024-04-23 17-16-17@2x](https://github.com/booqable/impact-theme/assets/40244261/23f69f40-5105-421c-93c8-0af526db8153)
