### PR TITLE
Change the Title inputs to plain text editors

### DIFF
--- a/assets/rx.css
+++ b/assets/rx.css
@@ -6,31 +6,10 @@
   list-style: decimal;
 }
 
-.bq-content.rx-content:not(.hero__title) {
+.bq-content.rx-content {
   font-family: var(--font-body);
   line-height: var(--line-height-lg);
   font-size: inherit;
-}
-
-:is(.bq-content.rx-content):is(h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6) {
-  font-family: var(--font-heading);
-  line-height: var(--line-height-xs);
-}
-
-:is(.bq-content.rx-content):is(h1, .h1, h2, .h2, h3, .h3) {
-  line-height: var(--line-height-sm);
-}
-
-:is(.bq-content.rx-content):is(h4, .h4) {
-  line-height: var(--line-height-md);
-}
-
-:is(.bq-content.rx-content):is(h5, .h5, h6, .h6) {
-  line-height: 1.4;
-}
-
-:is(.bq-content.rx-content):is(h1, .h1, h2, .h2, h3, .h3) * {
-  line-height: inherit;
 }
 
 .bq-content.rx-content h1 + *,

--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -186,7 +186,7 @@
           <div class="hero__text-area{% if show_overlay %} hero__text-area--color{%- endif -%}">
             <div class="hero__content">
               {%- if title != blank -%}
-                <h1 class="hero__title bq-content rx-content">{{- title -}}</h1>
+                <h1 class="hero__title">{{- title -}}</h1>
               {%- endif -%}
 
               {%- if description != blank -%}
@@ -308,10 +308,11 @@
         "default": "set-4"
       },
       {
-        "type": "contentEditor",
+        "type": "text",
         "id": "title",
         "label": "Title",
-        "default": "Explore like <br> a daredevil"
+        "default": "Explore like <br> a daredevil",
+        "info": "For breaking lines use <br> tag"
       },
       {
         "type": "contentEditor",


### PR DESCRIPTION
Currently, we are using `rich text` editor for the `Titles`. This can cause weird issues because of nesting of HTML elements within `<h1>` of the `Title`. 
For example, in the Chameleon theme, the customer had SEO issues with the heading of a Hero section. The heading that they added was saved in `<h1><p></p></h1>`, causing the "empty heading" SEO issue.

So, to avoid issues like that in the Impact theme `rich text` editors should be replaced with `plain text` editors as well. 

![314206001](https://github.com/booqable/impact-theme/assets/40244261/1223fa0e-5373-47dc-a134-a342f0bea3d4)
<img width="376" alt="326tre2y8r" src="https://github.com/booqable/impact-theme/assets/40244261/8713dd45-b866-4d57-b4ba-9720af5aa915">
