### PR TITLE
Remove function that adds prefixes to phone number or email in Top bar

### DIFF
--- a/assets/header.js
+++ b/assets/header.js
@@ -5,10 +5,8 @@ class Header {
     this.selector = {
       body: "body",
       bar: ".top-bar",
-      barBlock: ".top-bar__text",
       view: ".preview-bar__container",
-      inner: ".header__inner",
-      link: "a"
+      inner: ".header__inner"
     }
 
     this.classes = {
@@ -27,10 +25,6 @@ class Header {
       transform: '--header-transform'
     }
 
-    this.attr = {
-      href: "href"
-    }
-
     this.minHeight = 120;
     this.last = 0;
   }
@@ -47,14 +41,12 @@ class Header {
     this.body = document.querySelector(this.selector.body);
     this.preview = document.querySelector(this.selector.view);
     this.bar = this.header.querySelector(this.selector.bar);
-    this.barBlocks = this.header.querySelectorAll(this.selector.barBlock);
     this.inner = this.header.querySelector(this.selector.inner);
     this.isSticky = this.header.classList.contains(this.classes.sticky);
   }
 
   events() {
     this.headerHeight();
-    this.setEmailPhone();
 
     window.addEventListener("scroll", this.scrollProps.bind(this));
     window.addEventListener("resize", this.headerHeight.bind(this));
@@ -114,36 +106,6 @@ class Header {
     }
 
     this.last = current;
-  }
-
-  // convert links to allow users to send emails and call phone numbers
-  setEmailPhone() {
-    if (!this.barBlocks.length) return false;
-
-    const keepOnly = /[^a-zA-Z0-9,\-.?!@+]/g,
-          specChars = /[\()\-\s]/g,
-          phoneRegex = /(?:[-+() ]*\d){10,13}/gm,
-          emailRegex = /(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;
-
-    this.barBlocks.forEach(block => {
-      const links = block.querySelectorAll(this.selector.link);
-
-      if (!links.length) return false;
-
-      links.forEach(link => {
-        let href = link.getAttribute(this.attr.href);
-        const match = href.match(phoneRegex) || href.match(emailRegex);
-
-        if (match?.length) {
-          href = match[0].replace(keepOnly, '');
-
-          if (href.match(phoneRegex)) href = `tel:${href.replaceAll(specChars, '')}`;
-          if (href.match(emailRegex)) href = `mailto:${href}`;
-
-          link.setAttribute(this.attr.href, href);
-        }
-      })
-    })
   }
 
   setCssVar(key, val) {

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -75,7 +75,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "Get 15% off with code <b>ADRENALINE</b> at checkout",
-            "bar_text": "Call Us 24/7 <a href=\"+1 555 302 8549\">+1 555 302 8549</a>",
+            "bar_text": "Call Us 24/7 <a href=\"tel:+15553028549\">+1 555 302 8549</a>",
             "color_scheme": "set-4",
             "icon": "phone",
             "icon_style": "outline",
@@ -251,7 +251,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "Get 15% off with code <b>ADVENTURE</b> at checkout",
-            "bar_text": "Call Us 24/7 <a href=\"+1 555 302 8549\">+1 555 302 8549</a>",
+            "bar_text": "Call Us 24/7 <a href=\"tel:+15553028549\">+1 555 302 8549</a>",
             "color_scheme": "set-4",
             "icon": "phone",
             "icon_style": "outline",
@@ -436,7 +436,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "Get 15% off with code <b>DAREDEVIL</b> at checkout",
-            "bar_text": "Call Us 24/7 <a href=\"+1 555 302 8549\">+1 555 302 8549</a>",
+            "bar_text": "Call Us 24/7 <a href=\"tel:+15553028549\">+1 555 302 8549</a>",
             "color_scheme": "set-3",
             "icon": "phone",
             "icon_style": "outline",
@@ -621,7 +621,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "Get 15% off with code <b>EXPLORE</b> at checkout",
-            "bar_text": "Call Us 24/7 <a href=\"+1 555 302 8549\">+1 555 302 8549</a>",
+            "bar_text": "Call Us 24/7 <a href=\"tel:+15553028549\">+1 555 302 8549</a>",
             "color_scheme": "set-3",
             "icon": "phone",
             "icon_style": "outline",
@@ -806,7 +806,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "Get 15% off with code <b>FLOW</b> at checkout",
-            "bar_text": "Call Us 24/7 <a href=\"+1 555 302 8549\">+1 555 302 8549</a>",
+            "bar_text": "Call Us 24/7 <a href=\"tel:+15553028549\">+1 555 302 8549</a>",
             "color_scheme": "set-5",
             "icon": "phone",
             "icon_style": "outline",
@@ -991,7 +991,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "Get 15% off with code <b>PURE</b> at checkout",
-            "bar_text": "Call Us 24/7 <a href=\"+1 555 302 8549\">+1 555 302 8549</a>",
+            "bar_text": "Call Us 24/7 <a href=\"tel:+15553028549\">+1 555 302 8549</a>",
             "color_scheme": "set-3",
             "icon": "phone",
             "icon_style": "outline",


### PR DESCRIPTION
In the Chameleon theme we have already [fixed the issue](https://github.com/booqable/tough-theme/pull/195) reported by the customer that in the Topbar section in the theme builder, the option to add WhatsApp chat through a URL (wa.me/34611111111) doesn't work. It will only offer the option to call.
However, when this link is anywhere else embedded in a button, it does work.

So the PR's purpose is to remove the function that automatically finds and adds prefixes mailto: and tel: to email addresses and phone numbers accordingly from the Topbar section

![Arc_2024-04-23 18-25-33@2x](https://github.com/booqable/impact-theme/assets/40244261/edbb7193-cac5-474a-ae61-5adfc71cf1f4)
