### PR TITLE
Fix the issue when adding several accordions on the same page

### DIFF
--- a/sections/accordion.liquid
+++ b/sections/accordion.liquid
@@ -94,11 +94,11 @@
               <input
                 {% if behavior == "single" %}type="radio"{% else %}type="checkbox"{% endif %}
                 class="accordion__trigger"
-                id="accordion-item-{{- block.id -}}"
+                id="{{- section.key -}}-{{- block.id -}}"
                 name="accordion trigger"
               />
 
-              <label class="accordion__label" for="accordion-item-{{- block.id -}}">
+              <label class="accordion__label" for="{{- section.key -}}-{{- block.id -}}">
                 <h3 class="accordion__heading">
                   {{- heading -}}
                   {%- render 'icon-arrow-right' -%}


### PR DESCRIPTION
When adding several accordion sections on a page, only the first section works correctly, the other accordions won't drop down. It happens because of duplication of the same IDs

So the PR's goal is to add section ID to accordion items

