### PR TITLE
Add responsive styles for header logo image

### DIFF
--- a/assets/header.css
+++ b/assets/header.css
@@ -73,6 +73,7 @@
 
 .header__logo-image {
   max-height: 64px;
+  width: 100%;
 }
 
 .header__date-picker-wrapper {
@@ -465,6 +466,30 @@ body:has(#mobile-menu-opener:checked) .header:has(~ #main section:first-child > 
   color: var(--color-outline-hover);
 }
 
+@media (min-width: 320px) {
+  .header__logo-image {
+    max-width: 162px;
+  }
+}
+
+@media (min-width: 428px) {
+  .header__logo-image {
+    max-width: 210px;
+  }
+}
+
+@media (min-width: 480px) {
+  .header__logo-image {
+    max-width: 250px;
+  }
+}
+
+@media (min-width: 576px) {
+  .header__logo-image {
+    max-width: 300px;
+  }
+}
+
 @media (min-width: 992px) {
   .header__content-inner {
     grid-template-columns: 230px 1fr 230px;
@@ -500,10 +525,6 @@ body:has(#mobile-menu-opener:checked) .header:has(~ #main section:first-child > 
 
   .header__content--padding-bottom {
     padding-bottom: var(--padding-bottom);
-  }
-
-  .header__logo-wrapper:not(:empty) {
-    margin-right: 20px;
   }
 
   .header__date-picker-wrapper {


### PR DESCRIPTION
The menu icon doesn't appear on narrow screens if the logo is too wide. The logo width should be limited to display all next-to-it icons in header.

Before:
![Arc_2024-04-23 16-29-56@2x](https://github.com/booqable/impact-theme/assets/40244261/8cfbd99f-0e28-4580-8a06-256dee25a954)

After:
![Arc_2024-04-24 16-29-24@2x](https://github.com/booqable/impact-theme/assets/40244261/7f428e24-11d6-4813-974d-45a9a8ecb415)
