### PR TITLE
Add meta data

### DIFF
--- a/config/meta.json
+++ b/config/meta.json
@@ -1,0 +1,44 @@
+{
+  "adrenaline": {
+    "detail_url": "https://booqable.com/themes/adrenaline/",
+    "preview_url": "https://adrenaline.booqable.shop/",
+    "remote_preview_image_url": "https://booqable-files.s3.amazonaws.com/adrenaline_preview.png",
+    "version": 1,
+    "market": "Vehicle / Trailers"
+  },
+  "flow": {
+    "detail_url": "https://booqable.com/themes/flow/",
+    "preview_url": "https://flow.booqable.shop/",
+    "remote_preview_image_url": "https://booqable-files.s3.amazonaws.com/flow_preview.png",
+    "version": 1,
+    "market": "Boats / Kayaks"
+  },
+  "pure": {
+    "detail_url": "https://booqable.com/themes/pure/",
+    "preview_url": "https://pure.booqable.shop/",
+    "remote_preview_image_url": "https://booqable-files.s3.amazonaws.com/pure_preview.png",
+    "version": 1,
+    "market": "Sports / Activities"
+  },
+  "daredevil": {
+    "detail_url": "https://booqable.com/themes/daredevil/",
+    "preview_url": "https://daredevil.booqable.shop/",
+    "remote_preview_image_url": "https://booqable-files.s3.amazonaws.com/daredevil_preview.png",
+    "version": 1,
+    "market": "Bikes / Scooters"
+  },
+  "adventure": {
+    "detail_url": "https://booqable.com/themes/adventure/",
+    "preview_url": "https://adventure.booqable.shop/",
+    "remote_preview_image_url": "https://booqable-files.s3.amazonaws.com/adventure_preview.png",
+    "version": 1,
+    "market": "Sports / Activities"
+  },
+  "explore": {
+    "detail_url": "https://booqable.com/themes/explore/",
+    "preview_url": "https://explore.booqable.shop/",
+    "remote_preview_image_url": "https://booqable-files.s3.amazonaws.com/explore_preview.png",
+    "version": 1,
+    "market": "Vehicle / Trailers"
+  }
+}


### PR DESCRIPTION
We want to allow automatic setting of the theme meta data upon installation.
Meta data includes links to store previews, theme thumbnails and other data necessary for the theme store.

Currently we're doing this manually though production console which is not very convenient.

This is still not supported on Booqable main app side, but this PR provides correct meta data for all current Impact theme. It can be used for testing of [SHOP-1108](https://linear.app/booqable/issue/SHOP-1108/introduce-meta-configuration-for-themes)