### PR TITLE
Add missing minicart color variables

### DIFF
--- a/snippets/variables-mini-cart.liquid
+++ b/snippets/variables-mini-cart.liquid
@@ -1,6 +1,8 @@
 {% style %}
   [data-tid="Mini cart"] {
     --minicart-accent-color: var(--background-accent);
+    --minicart-accent-outline: var(--color-outline);
+    --minicart-accent-text-color: var(--color-accent);
     --minicart-background-color: var(--background-primary);
     --minicart-typo-color: var(--color-primary);
     --minicart-header-color: var(--color-accent);


### PR DESCRIPTION
Since we've  added new color variables for mini cart in Chameleon theme, then then they should be exist in Impact too