### PR TITLE
Fix stretch logo in Safari

### DIFF
--- a/assets/header.css
+++ b/assets/header.css
@@ -73,7 +73,6 @@
 
 .header__logo-image {
   max-height: 64px;
-  width: 100%;
 }
 
 .header__date-picker-wrapper {


### PR DESCRIPTION
An issue with the header logo, when the website is visited in Safari the logo is stretched but this doesn't happen with Chrome, Firefox or Edge

Before:
![image (76)](https://github.com/booqable/impact-theme/assets/40244261/e29378f2-cb39-49e3-8b1f-ffb90ac504e4)


After:
![Safari_2024-05-06 11-40-24@2x](https://github.com/booqable/impact-theme/assets/40244261/9311b317-9549-4f3a-ae67-290dbcc15f89)

