### PR TITLE
Fix blurry product images on mobile

### DIFF
--- a/snippets/image.liquid
+++ b/snippets/image.liquid
@@ -50,6 +50,7 @@
     l - Image is wide as half of the viewport
     xl - Image is wide as 3/4 of the viewport
     xxl - Image is as wide as the whole viewport
+    flexible - Image is wide as the viewport on small screens but is smaller relative to the screen on larger screens
     logo - Image has the same size and quality on all resolutions
   {% endcomment %}
 
@@ -72,6 +73,9 @@
     {%- when 'xxl' -%}
       {%- assign image_width = '320, 480, 768, 1200, 1680, 2560' -%}
       {%- assign image_sizes = '(max-width: 320px) 320px, (max-width: 480px) 480px, (max-width: 768px) 768px, (max-width: 1200px) 1200px, (max-width: 1680px) 1680px, 2560px' -%}
+    {%- when 'flexible' -%}
+      {%- assign image_width = '320, 480, 576, 900, 840, 1280' -%}
+      {%- assign image_sizes = '(max-width: 320px) 320px, (max-width: 480px) 480px, (max-width: 768px) 576px, (max-width: 1200px) 900px, (max-width: 1680px) 840px, 1280px' -%}
     {%- when 'logo' -%}
       {%- assign image_width = '420, 640' -%}
       {%- assign image_sizes = '(max-width: 360px) 420px, 640px' -%}

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -41,7 +41,7 @@
   {%- endif -%}
 
   {%- if img_size == blank -%}
-    {%- assign img_size = 'm' -%}
+    {%- assign img_size = 'flexible' -%}
   {%- endif -%}
 
   {% if focal %}


### PR DESCRIPTION
We dynamically load the correct size of the image depending on the screen size.
Additionally, you can decide what image size to load relative to the screen size.
For example, the `l` image will load an image that is approximately 50% of the viewport width, while `xxl` will load an image that is around 100% of the width.

This works well, except for situation where on mobile we load a full-width image, and on the desktop, we load a smaller image. See example:

![Screenshot_2024-05-29 13-29-22@2x](https://github.com/booqable/impact-theme/assets/40244261/29647165-63db-453a-a1d5-f88910592526)

![Arc_2024-05-29 13-30-56@2x](https://github.com/booqable/impact-theme/assets/40244261/2a25201a-e623-4250-b1a1-48b7439c5feb)
