### PR TITLE
Font-awesome `clock` icon fix

### DIFF
--- a/sections/top-bar.liquid
+++ b/sections/top-bar.liquid
@@ -144,7 +144,7 @@
             "label": "Calendar"
           },
           {
-            "value": "clock-o",
+            "value": "clock",
             "label": "Clock"
           },
           {


### PR DESCRIPTION
The `clock` icon doesn't display in the Top bar section. It was reused from the Chameleon theme but in Impact some of the font-awesome icons don't work as expected because they should have outline style

**Before**:
![Arc_2024-05-29 13-57-15@2x](https://github.com/booqable/impact-theme/assets/40244261/a8081611-6664-4f84-b3e2-a7e911577a42)


**After**:
![Arc_2024-05-29 14-00-10@2x](https://github.com/booqable/impact-theme/assets/40244261/bba42ec4-edef-40da-9a6c-d6bc10a4985c)
