### PR TITLE
Fix auto increasing font-size on iPhone in landscape mode

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -102,6 +102,10 @@ html {
   padding: env(safe-area-inset);
 }
 
+.touch {
+  -webkit-text-size-adjust: 100%;
+}
+
 body {
   background: var(--background-primary);
   color: var(--color-primary);


### PR DESCRIPTION
While developing the Horton theme I noticed that in Safari on iPhone in portrait mode some text font size displays 14px (as expected), but when I switch the device to landscape it automatically blows up to 21px. 
The same issue exists in the Impact theme

The PR's goal is to preserve HTML font size when iPhone orientation changes from portrait to landscape

### _**Before:**_
![IMG_5856](https://github.com/booqable/impact-theme/assets/40244261/613becc0-9eae-4d8d-a66e-e65d4631510c)

### _**After:**_
![IMG_5855](https://github.com/booqable/impact-theme/assets/40244261/508f6647-6332-43d1-bbb6-56d343ffb38e)
