### PR TITLE
Fix elliptical circle

### DIFF
--- a/assets/collections.css
+++ b/assets/collections.css
@@ -65,6 +65,7 @@
 .collections__arrow {
   height: 55px;
   width: 55px;
+  flex: 0 0 55px;
   margin-bottom: 10px;
   border-radius: var(--border-radius);
   display: flex;


### PR DESCRIPTION
The PR's purpose is to fix the circle arrow that gets an ellipse if the collection title is too long

Before:
![Arc_2024-06-03 11-26-54@2x](https://github.com/booqable/impact-theme/assets/40244261/4bde9ca2-4653-4882-8284-0409ae4e4f90)


After:
![Arc_2024-06-03 11-27-21@2x](https://github.com/booqable/impact-theme/assets/40244261/ea5b9878-5833-47db-9579-15f1fe803872)
