### PR TITLE
Update collection page grid layout in mode of 4 products in row

### DIFF
--- a/assets/collection-page.css
+++ b/assets/collection-page.css
@@ -103,6 +103,6 @@
 @media (min-width: 1080px) {
   .collection-page__products {
     gap: 20px 32px;
-    grid-template-columns: repeat(var(--grid-element), minmax(210px, 1fr));
+    grid-template-columns: repeat(var(--grid-element), minmax(var(--item-min-width), 1fr));
   }
 }

--- a/sections/collection-page.liquid
+++ b/sections/collection-page.liquid
@@ -88,10 +88,13 @@
   {%- case grid -%}
     {%- when 'two' -%}
       --grid-element: 2;
+      --item-min-width: 300px;
     {%- when 'three' -%}
       --grid-element: 3;
+      --item-min-width: 210px;
     {%- when 'four' -%}
       --grid-element: 4;
+      --item-min-width: 160px;
   {%- endcase -%}
 
   {%- case rounded_corners -%}


### PR DESCRIPTION
The PR's goal is to update the collection page grid layout to use dynamic column widths based on the selected grid option. This improves the responsiveness and visual consistency of the page. The grid now adjusts the minimum width of each item based on the grid option selected: 
- For 'two' grid option, the minimum width is set to 300px.
- For 'three' grid option, the minimum width is set to 210px.
- For 'four' grid option, the minimum width is set to 160px.

Before:
![Arc_2024-06-03 16-39-38@2x](https://github.com/booqable/impact-theme/assets/40244261/52f7a235-2148-4e99-8ba6-1fb6b7f4aaf1)


After:
![Arc_2024-06-03 16-40-02@2x](https://github.com/booqable/impact-theme/assets/40244261/9d962d9f-f81d-4ce8-90f0-a555e82fcac3)

