### PR TITLE
Add carousel item max-width

### DIFF
--- a/assets/carousel.css
+++ b/assets/carousel.css
@@ -46,6 +46,7 @@
 .carousel__item {
   position: relative;
   min-width: var(--slide-width-mobile);
+  max-width: var(--slide-width-mobile);
   padding: 0;
   scroll-snap-align: start;
   scroll-snap-stop: always;
@@ -53,6 +54,7 @@
 
 .carousel__item:last-child {
   min-width: calc(var(--slide-width-mobile) + 16px);
+  max-width: calc(var(--slide-width-mobile) + 16px);
 }
 
 .carousel__item:last-child .carousel__inner {
@@ -159,10 +161,12 @@
 
   .carousel__item {
     min-width: var(--slide-width);
+    max-width: var(--slide-width);
   }
 
   .carousel__item:last-child {
     min-width: calc(var(--slide-width) + 16px);
+    max-width: calc(var(--slide-width) + 16px);
   }
 }
 
@@ -174,10 +178,12 @@
 
   .carousel__item {
     min-width: var(--slide-width);
+    max-width: var(--slide-width);
   }
 
   .carousel__item:last-child {
     min-width: calc(var(--slide-width) - 16px);
+    max-width: calc(var(--slide-width) - 16px);
   }
 
   .carousel__inner {


### PR DESCRIPTION
Currently, if the Product section has less than 4 items, the `Show product description excerpt` is enabled and some products don't have a description at all, so they look differently from each other, and their width varies

The PR's goal is to limit the max-width 

Before:
![Arc_2024-06-12 12-35-06@2x](https://github.com/booqable/impact-theme/assets/40244261/8a74ef1d-8c4f-445b-a6c8-143c8973d87c)


After:

![Arc_2024-06-12 12-34-26@2x](https://github.com/booqable/impact-theme/assets/40244261/11f04666-77f9-48d9-9936-269c409bb2bc)
