### PR TITLE
Avoid broken layout with long words

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -117,6 +117,7 @@ body {
   min-height: 100%;
   width: 100%;
   overflow-x: clip;
+  word-break: break-word;
 }
 
 body > * {

--- a/assets/base.css
+++ b/assets/base.css
@@ -117,7 +117,7 @@ body {
   min-height: 100%;
   width: 100%;
   overflow-x: clip;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 body > * {

--- a/assets/footer.css
+++ b/assets/footer.css
@@ -39,7 +39,6 @@
   line-height: var(--line-height-md);
   font-weight: var(--font-weight-semibold);
   margin: 0;
-  word-break: break-word;
   color: var(--color-primary);
 }
 

--- a/assets/header.css
+++ b/assets/header.css
@@ -68,7 +68,6 @@
   font-weight: var(--font-weight-semibold);
   margin: 0;
   color: currentColor;
-  word-break: break-word;
 }
 
 .header__logo-image {


### PR DESCRIPTION
Currently, we can get a broken layout with too long words, especially it's clearly visible on narrow blocks such as in the Columns section. So in this case we have a `contentEditor` field and the customer added the email and wrapped it in the heading tag but it goes out of the block.

So this PR's purpose is to add the CSS `break-word` property and avoid such issues throughout the layout.

Before:
<img width="356" alt="Screenshot 2024-06-20 at 14 31 39" src="https://github.com/booqable/impact-theme/assets/40244261/d9436b76-c86b-4913-92b6-8ddf253d63e5">

![Arc_2024-06-24 13-24-40@2x](https://github.com/booqable/impact-theme/assets/40244261/901ac0c7-00a2-4b8f-ad64-651eab661205)


After:
![Arc_2024-06-24 13-27-12@2x](https://github.com/booqable/impact-theme/assets/40244261/896c5d43-6032-42f3-8450-a5fb8f9f0b7a)



