### PR TITLE
Strip HTML before truncating to avoid not-closed tags

### DIFF
--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -51,7 +51,7 @@
   {%- assign id      = product.id -%}
   {%- assign url     = product.url -%}
   {%- assign name    = product.name -%}
-  {%- assign excerpt = product.description | truncatewords: 20, " ..."  -%}
+  {%- assign excerpt = product.description | strip_html | truncatewords: 20, " ..."  -%}
   {%- assign price   = product | product_price -%}
   {%- assign period  = product | product_price_label -%}
 


### PR DESCRIPTION
We allow customers to add HTML in product descriptions, this caused an issue when truncating them.
Example:
`<b>This is a very long description that is bold</b>`
Would be truncated to
`<b>This is a very long...`
Which would leave us with an unclosed tag that would break the layout.

So the solution is to make sure to strip HTML tags before truncating and avoid breaking the layout.

Before:
![Arc_2024-06-25 16-05-36@2x](https://github.com/booqable/impact-theme/assets/40244261/d00add91-b5bc-4950-bffa-9de0558bc2e0)


After:
![Arc_2024-06-25 16-06-03@2x](https://github.com/booqable/impact-theme/assets/40244261/907e224e-25af-4937-a9b8-a906b206aa07)

