### PR TITLE
Fix the input type of `color_scheme` in the schema

### DIFF
--- a/sections/spacer.liquid
+++ b/sections/spacer.liquid
@@ -52,7 +52,7 @@
         "content": "General settings"
       },
       {
-        "type": "select",
+        "type": "color_scheme",
         "id": "color_scheme",
         "label": "Color scheme",
         "default": "set-1"


### PR DESCRIPTION
Currently, when we try to open in the theme editor the Spacer section, the page freezes and only reloading can help. 
This is caused because in this section there are inconsistencies in the schema with some types of input fields, and the `select` input type is used for color schemes instead of `color_scheme` type