### PR TITLE
Remove stripping html and truncating of product excerpts

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -3,8 +3,7 @@ class Main {
     this.body = body;
 
     this.selector = {
-      image: ".focal-image",
-      productDescription: ".product-card__description"
+      image: ".focal-image"
     }
 
     this.modifier = {
@@ -26,19 +25,13 @@ class Main {
   init() {
     if (!this.body) return false;
 
-    this.elements();
     this.events();
-  }
-
-  elements() {
-    this.productDescriptions = document.querySelectorAll(this.selector.productDescription);
   }
 
   events() {
     this.getBodyHeight();
     this.setLoadedClass();
     this.focalImages();
-    this.truncateDescription();
 
     window.addEventListener("resize", this.getBodyHeight.bind(this));
   }
@@ -88,48 +81,6 @@ class Main {
 
       image.style.opacity = 1;
     })
-  }
-
-  // truncate product description
-  truncateDescription() {
-    if (!this.productDescriptions.length) return false;
-
-    this.productDescriptions.forEach(description => this.truncateText(description, 125))
-  }
-
-  truncateText(element, maxLength) {
-    const text = element.innerHTML;
-    const truncatedText = this.truncateString(text, maxLength);
-    element.innerHTML = truncatedText;
-  }
-
-  truncateString(str, num) {
-    let totalLength = 0,
-        result = "";
-
-    for (let i = 0; i < str.length; i++) {
-      if (totalLength >= num) {
-        result += " ...";
-        break;
-      }
-
-      const char = str[i];
-
-      if (char === "<") {
-        const endTagIndex = str.indexOf(">", i);
-
-        if (endTagIndex !== -1) {
-          const tag = str.substring(i, endTagIndex + 1);
-          result += tag;
-          i = endTagIndex;
-        }
-      } else {
-        result += char;
-        totalLength++;
-      }
-    }
-
-    return result;
   }
 }
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -3,7 +3,8 @@ class Main {
     this.body = body;
 
     this.selector = {
-      image: ".focal-image"
+      image: ".focal-image",
+      productDescription: ".product-card__description"
     }
 
     this.modifier = {
@@ -25,13 +26,19 @@ class Main {
   init() {
     if (!this.body) return false;
 
+    this.elements();
     this.events();
+  }
+
+  elements() {
+    this.productDescriptions = document.querySelectorAll(this.selector.productDescription);
   }
 
   events() {
     this.getBodyHeight();
     this.setLoadedClass();
     this.focalImages();
+    this.truncateDescription();
 
     window.addEventListener("resize", this.getBodyHeight.bind(this));
   }
@@ -81,6 +88,48 @@ class Main {
 
       image.style.opacity = 1;
     })
+  }
+
+  // truncate product description
+  truncateDescription() {
+    if (!this.productDescriptions.length) return false;
+
+    this.productDescriptions.forEach(description => this.truncateText(description, 125))
+  }
+
+  truncateText(element, maxLength) {
+    const text = element.innerHTML;
+    const truncatedText = this.truncateString(text, maxLength);
+    element.innerHTML = truncatedText;
+  }
+
+  truncateString(str, num) {
+    let totalLength = 0,
+        result = "";
+
+    for (let i = 0; i < str.length; i++) {
+      if (totalLength >= num) {
+        result += " ...";
+        break;
+      }
+
+      const char = str[i];
+
+      if (char === "<") {
+        const endTagIndex = str.indexOf(">", i);
+
+        if (endTagIndex !== -1) {
+          const tag = str.substring(i, endTagIndex + 1);
+          result += tag;
+          i = endTagIndex;
+        }
+      } else {
+        result += char;
+        totalLength++;
+      }
+    }
+
+    return result;
   }
 }
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -18,7 +18,10 @@ class Main {
     }
 
     this.cssVar = {
-      bodyHeight: '--body-height',
+      bodyHeight: '--body-height'
+    }
+
+    this.cssProp = {
       maxHeight: 'max-height',
       paddingTop: 'padding-top',
       paddingBottom: 'padding-bottom'
@@ -54,13 +57,14 @@ class Main {
     this.setCssVar(this.cssVar.bodyHeight, height);
   }
 
+  // set class for truncation product card description
   setTruncationClass() {
     if (!this.excerpts.length) return false;
 
     const styles = window.getComputedStyle(this.excerpts[0]),
-          paddingTop = parseInt(styles.getPropertyValue(this.cssVar.paddingTop)),
-          paddingBottom = parseInt(styles.getPropertyValue(this.cssVar.paddingBottom)),
-          maxHeight = parseInt(styles.getPropertyValue(this.cssVar.maxHeight)),
+          paddingTop = parseInt(styles.getPropertyValue(this.cssProp.paddingTop)),
+          paddingBottom = parseInt(styles.getPropertyValue(this.cssProp.paddingBottom)),
+          maxHeight = parseInt(styles.getPropertyValue(this.cssProp.maxHeight)),
           minHeight = maxHeight / 2 + paddingBottom + paddingTop;
 
     this.excerpts.forEach(excerpt => {

--- a/assets/main.js
+++ b/assets/main.js
@@ -3,11 +3,13 @@ class Main {
     this.body = body;
 
     this.selector = {
-      image: ".focal-image"
+      image: ".focal-image",
+      excerpt: ".product-card__description"
     }
 
     this.modifier = {
-      loaded: "loaded"
+      loaded: "loaded",
+      truncated: "truncated"
     }
 
     this.data = {
@@ -16,7 +18,10 @@ class Main {
     }
 
     this.cssVar = {
-      bodyHeight: '--body-height'
+      bodyHeight: '--body-height',
+      maxHeight: 'max-height',
+      paddingTop: 'padding-top',
+      paddingBottom: 'padding-bottom'
     }
 
     this.focalImageTimeout;
@@ -25,21 +30,46 @@ class Main {
   init() {
     if (!this.body) return false;
 
+    this.elements();
     this.events();
+  }
+
+  elements() {
+    this.excerpts = document.querySelectorAll(this.selector.excerpt);
   }
 
   events() {
     this.getBodyHeight();
     this.setLoadedClass();
     this.focalImages();
+    this.setTruncationClass();
 
     window.addEventListener("resize", this.getBodyHeight.bind(this));
+    window.addEventListener("resize", this.setTruncationClass.bind(this));
   }
 
   getBodyHeight() {
     const height = this.body.getBoundingClientRect().height
 
     this.setCssVar(this.cssVar.bodyHeight, height);
+  }
+
+  setTruncationClass() {
+    if (!this.excerpts.length) return false;
+
+    const styles = window.getComputedStyle(this.excerpts[0]),
+          paddingTop = parseInt(styles.getPropertyValue(this.cssVar.paddingTop)),
+          paddingBottom = parseInt(styles.getPropertyValue(this.cssVar.paddingBottom)),
+          maxHeight = parseInt(styles.getPropertyValue(this.cssVar.maxHeight)),
+          minHeight = maxHeight / 2 + paddingBottom + paddingTop;
+
+    this.excerpts.forEach(excerpt => {
+      const height = excerpt.getBoundingClientRect().height
+
+      height > minHeight
+        ? excerpt.classList.add(this.modifier.truncated)
+        : excerpt.classList.remove(this.modifier.truncated)
+    })
   }
 
   setCssVar(key, val) {

--- a/assets/product-card.css
+++ b/assets/product-card.css
@@ -81,6 +81,26 @@
   padding-bottom: 0;
 }
 
+.product-card__description.truncated {
+  position: relative;
+  flex-grow: 1;
+}
+
+.product-card__description.truncated + .product-card__price-info {
+  flex-grow: 0;
+}
+
+.product-card__description.truncated:after {
+  content: "";
+  display: block;
+  width: 100%;
+  height: 60px;
+  background: linear-gradient(to top, var(--background-primary) 0%, var(--background-primary) 30%, var(--background-primary-00) 100%);
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+
 .product-card__meta .product-card__description dt,
 .product-card__meta .product-card__description dd,
 .product-card__meta .product-card__description li,
@@ -101,8 +121,6 @@
 .product-card__price-wrapper {
   display: flex;
   align-items: flex-end;
-  width: 100%;
-  position: relative;
 }
 
 .product-card__price,
@@ -124,17 +142,6 @@ bq-product-availability {
 bq-product-availability[visible="true"] {
   display: inline-block;
   margin: 9px 0 16px;
-}
-
-.product-card__meta:has(.product-card__description) .product-card__price-wrapper:before {
-  content: "";
-  display: block;
-  width: 100%;
-  height: 76px;
-  background: linear-gradient(to top, var(--background-primary) 0%, var(--background-primary) 28%, var(--background-primary-00) 100%);
-  position: absolute;
-  bottom: 100%;
-  left: 0;
 }
 
 @media (min-width: 992px) {

--- a/assets/product-card.css
+++ b/assets/product-card.css
@@ -56,7 +56,6 @@
   font-size: calc(var(--font-size-regular) - 2px);
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
 }
 
 .product-card--full-border .product-card__meta {
@@ -76,13 +75,6 @@
   flex-grow: 0;
 }
 
-.product-card__meta .product-card__description dt,
-.product-card__meta .product-card__description dd,
-.product-card__meta .product-card__description li,
-.product-card__meta .product-card__description li li {
-  font-size: inherit;
-}
-
 .product-card__description:last-child {
   padding-bottom: 0;
 }
@@ -100,6 +92,8 @@
 .product-card__price-wrapper {
   display: flex;
   align-items: flex-end;
+  width: 100%;
+  position: relative;
 }
 
 .product-card__price,
@@ -121,6 +115,17 @@ bq-product-availability {
 bq-product-availability[visible="true"] {
   display: inline-block;
   margin: 9px 0 16px;
+}
+
+.product-card__meta:has(.product-card__description) .product-card__price-wrapper:before {
+  content: "";
+  display: block;
+  width: 100%;
+  height: 76px;
+  background: linear-gradient(to top, var(--background-primary) 0%, var(--background-primary) 20%, var(--background-primary-00) 100%);
+  position: absolute;
+  bottom: 100%;
+  left: 0;
 }
 
 @media (min-width: 992px) {

--- a/assets/product-card.css
+++ b/assets/product-card.css
@@ -73,10 +73,19 @@
 .product-card__description {
   padding: 4px 0 8px;
   flex-grow: 0;
+  overflow: hidden;
+  max-height: 130px;
 }
 
 .product-card__description:last-child {
   padding-bottom: 0;
+}
+
+.product-card__meta .product-card__description dt,
+.product-card__meta .product-card__description dd,
+.product-card__meta .product-card__description li,
+.product-card__meta .product-card__description li li {
+  font-size: inherit;
 }
 
 .product-card__price-info {
@@ -122,7 +131,7 @@ bq-product-availability[visible="true"] {
   display: block;
   width: 100%;
   height: 76px;
-  background: linear-gradient(to top, var(--background-primary) 0%, var(--background-primary) 20%, var(--background-primary-00) 100%);
+  background: linear-gradient(to top, var(--background-primary) 0%, var(--background-primary) 28%, var(--background-primary-00) 100%);
   position: absolute;
   bottom: 100%;
   left: 0;

--- a/assets/product-card.css
+++ b/assets/product-card.css
@@ -53,6 +53,7 @@
 
 .product-card__meta {
   padding: 15px 0;
+  font-size: calc(var(--font-size-regular) - 2px);
   display: flex;
   flex-direction: column;
   flex-grow: 1;
@@ -71,9 +72,15 @@
 }
 
 .product-card__description {
-  font-size: calc(var(--font-size-regular) - 2px);
   padding: 4px 0 8px;
   flex-grow: 0;
+}
+
+.product-card__meta .product-card__description dt,
+.product-card__meta .product-card__description dd,
+.product-card__meta .product-card__description li,
+.product-card__meta .product-card__description li li {
+  font-size: inherit;
 }
 
 .product-card__description:last-child {

--- a/sections/articles.liquid
+++ b/sections/articles.liquid
@@ -159,7 +159,7 @@
                     {%- endif -%}
 
                     {%- if text != blank -%}
-                      <div class="articles__text bq-content rx-content">{{- text | truncatewords: 35, " ..."  -}}</div>
+                      <div class="articles__text bq-content rx-content">{{- text -}}</div>
                     {%- endif -%}
 
                     {%- if article_btn != blank and article_btn_url != blank -%}

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -55,6 +55,16 @@
   {%- assign price   = product | product_price -%}
   {%- assign period  = product | product_price_label -%}
 
+  {%- unless excerpt.contains ";</li" or excerpt.contains ".</li" or excerpt.contains "; </li" or excerpt.contains ". </li" -%}
+    {%- assign excerpt = excerpt | replace: "</li", "; </li" -%}
+    {%- assign excerpt = excerpt | replace: ";;", "; " -%}
+    {%- assign excerpt = excerpt | replace: "; ;", "; " -%}
+    {%- assign excerpt = excerpt | replace: ".;", "." -%}
+    {%- assign excerpt = excerpt | replace: ". ;", ". " -%}
+  {%- endunless -%}
+
+  {%- assign excerpt = excerpt | strip_html | truncatewords: 25, "" -%}
+
 {%- else -%}
   {%- if placeholder != blank -%}
     {%- assign image = placeholder -%}
@@ -103,7 +113,7 @@
     </h3>
 
     {%- if excerpt != blank and show_excerpt -%}
-      <div class="product-card__description bq-content rx-content">{{- excerpt -}}</div>
+      <div class="product-card__description">{{- excerpt -}}</div>
     {%- endif -%}
 
     {%- if price != blank and period != blank -%}

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -54,17 +54,6 @@
   {%- assign excerpt = product.description -%}
   {%- assign price   = product | product_price -%}
   {%- assign period  = product | product_price_label -%}
-
-  {%- unless excerpt.contains ";</li" or excerpt.contains ".</li" or excerpt.contains "; </li" or excerpt.contains ". </li" -%}
-    {%- assign excerpt = excerpt | replace: "</li", "; </li" -%}
-    {%- assign excerpt = excerpt | replace: ";;", "; " -%}
-    {%- assign excerpt = excerpt | replace: "; ;", "; " -%}
-    {%- assign excerpt = excerpt | replace: ".;", "." -%}
-    {%- assign excerpt = excerpt | replace: ". ;", ". " -%}
-  {%- endunless -%}
-
-  {%- assign excerpt = excerpt | strip_html | truncatewords: 25, "" -%}
-
 {%- else -%}
   {%- if placeholder != blank -%}
     {%- assign image = placeholder -%}
@@ -113,7 +102,7 @@
     </h3>
 
     {%- if excerpt != blank and show_excerpt -%}
-      <div class="product-card__description">{{- excerpt -}}</div>
+      <div class="product-card__description bq-content rx-content">{{- excerpt -}}</div>
     {%- endif -%}
 
     {%- if price != blank and period != blank -%}

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -51,7 +51,7 @@
   {%- assign id      = product.id -%}
   {%- assign url     = product.url -%}
   {%- assign name    = product.name -%}
-  {%- assign excerpt = product.description | strip_html | truncatewords: 20, " ..."  -%}
+  {%- assign excerpt = product.description -%}
   {%- assign price   = product | product_price -%}
   {%- assign period  = product | product_price_label -%}
 
@@ -103,7 +103,7 @@
     </h3>
 
     {%- if excerpt != blank and show_excerpt -%}
-      <div class="product-card__description">{{- excerpt -}}</div>
+      <div class="product-card__description bq-content rx-content">{{- excerpt -}}</div>
     {%- endif -%}
 
     {%- if price != blank and period != blank -%}


### PR DESCRIPTION
This PR's goal is to remove `strip_html` and `truncatewords` filters to save all the styling of reach text.

Also, instead of 3 dots at the end, it should add a linear gradient to the bottom of the product description on product cards dynamically, because else if the description is too small it's overlapped with the gradient and is non-visible at all.

**Before**:
![Arc_2024-07-26 11-41-28@2x](https://github.com/user-attachments/assets/ddcc9ae2-dcfd-4246-b687-1ad1f87fa502)


**After**:
![Teampaper_2024-07-26 11-44-53@2x](https://github.com/user-attachments/assets/4b8723a4-0ba1-40a8-bdd5-f14ebe8286b8)
