### PR TITLE
Adding `show payments` option to the Footer

### DIFF
--- a/assets/footer.css
+++ b/assets/footer.css
@@ -16,7 +16,8 @@
 }
 
 .footer__container .footer__wrapper {
-  border-radius: var(--border-radius-rounded-blocks);
+  border-top-left-radius: var(--border-radius-rounded-blocks);
+  border-top-right-radius: var(--border-radius-rounded-blocks);
   padding-right: var(--horizontal-padding-mobile);
   padding-left: var(--horizontal-padding-mobile);
 }

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -3916,7 +3916,8 @@
             "padding_bottom_mobile": "small",
             "padding_top": "medium",
             "padding_top_mobile": "small",
-            "rounded_corners": "none"
+            "rounded_corners": "none",
+            "show_payments": true
           },
           "disabled": null
         }

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -12,6 +12,7 @@
 {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
 {%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
 {%- assign rounded_corners       = section.settings.rounded_corners -%}
+{%- assign show_payments         = section.settings.show_payments -%}
 {%- assign facebook              = settings.social_facebook_link -%}
 {%- assign instagram             = settings.social_instagram_link -%}
 {%- assign twitter               = settings.social_twitter_link -%}
@@ -159,7 +160,7 @@
         </div>
       {%- endif -%}
 
-      {%- if payment_methods.size > 0 -%}
+      {%- if show_payments and payment_methods.size > 0 -%}
         <div class="footer__payments payments">
           {%- render 'payments', payments: payment_methods -%}
         </div>
@@ -325,6 +326,12 @@
         "type": "checkbox",
         "id": "full_width",
         "label": "Full-width background",
+        "default": true
+      },
+      {
+        "type": "checkbox",
+        "id": "show_payments",
+        "label": "Show payment icons",
         "default": true
       },
       {

--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -343,7 +343,7 @@
         "type": "text",
         "id": "video_url",
         "label": "Video URL (optional)",
-        "info": "Youtube, Vimeo. If you paste video link here, any images will be ignored"
+        "info": "Youtube, Vimeo. If you paste video link here, any images will be ignored. Preferred format 16:9"
       },
       {
         "type": "checkbox",

--- a/sections/products.liquid
+++ b/sections/products.liquid
@@ -1,8 +1,28 @@
+{%- assign blocks     = section.blocks -%}
 {%- assign collection = section.settings.collection -%}
-{%- assign blocks = section.blocks -%}
 
-{%- if blocks.size > 0 or collection.items_count > 0 -%}
+{%- if collection != blank -%}
+  {%- assign items         = collection.items -%}
+  {%- assign items_type    = "collection" -%}
+  {%- assign size          = collection.items_count -%}
+{%- else -%}
+  {%- assign items         = blocks -%}
+  {%- assign items_type    = "blocks" -%}
+  {%- assign product_items = "" -%}
 
+  {%- for item in items -%}
+    {%- if product_items == "" -%}
+      {%- assign product_items = item.id -%}
+    {%- else -%}
+      {%- assign product_items = product_items | append: ", " | append: item.id -%}
+    {%- endif -%}
+  {%- endfor -%}
+
+  {%- assign product_items_arr = product_items | split: ", " -%}
+  {%- assign size = product_items_arr | size -%}
+{%- endif -%}
+
+{%- if size > 0 -%}
   {{ "products.css" | asset_url | stylesheet_tag }}
   {{ "product-card.css" | asset_url | stylesheet_tag }}
 
@@ -14,6 +34,7 @@
   {%- assign image_fit             = section.settings.image_fit -%}
   {%- assign image_placeholder     = settings.image_placeholder -%}
   {%- assign is_focal              = false -%}
+  {%- assign limit                 = 8 -%}
   {%- assign padding_top           = section.settings.padding_top -%}
   {%- assign padding_bottom        = section.settings.padding_bottom -%}
   {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
@@ -31,20 +52,16 @@
     {%- assign is_focal = true -%}
   {%- endif -%}
 
-  {%- if collection != blank -%}
-    {%- assign items = collection.items -%}
-    {%- assign items_type = "collection" -%}
-  {%- else -%}
-    {%- assign items = blocks -%}
-    {%- assign items_type = "blocks" -%}
-  {%- endif -%}
-
   {%- assign carousel = false -%}
 
-  {%- if blocks.size > 1 or collection.items_count > 1 -%}
+  {%- if size > 1 -%}
     {{ "carousel.css" | asset_url | stylesheet_tag }}
 
     {%- assign carousel = true -%}
+
+    {% unless show_pagination %}
+      {%- assign limit = nil -%}
+    {% endunless %}
   {%- endif -%}
 
   {%- assign border = false -%}
@@ -149,7 +166,7 @@
           <div class="carousel__wrapper">
         {%- endif -%}
 
-            {%- for item in items limit: 8 -%}
+            {%- for item in items limit: limit -%}
               {% case items_type %}
                 {% when "blocks" %}
                   {% assign product = item.settings.product %}
@@ -192,7 +209,7 @@
 
           {%- if show_pagination -%}
             <div class="carousel__pagination hidden" aria-role="Carousel navigation">
-              {%- for item in items limit: 8 -%}
+              {%- for item in items limit: limit -%}
                 {%- assign first = forloop.first -%}
                 {%- assign index = forloop.index -%}
 

--- a/sections/search.liquid
+++ b/sections/search.liquid
@@ -10,7 +10,7 @@
 {%- assign image_fit             = section.settings.image_fit -%}
 {%- assign image_placeholder     = settings.image_placeholder -%}
 {%- assign is_focal              = false -%}
-{%- assign limit                 = section.settings.limit -%}
+{%- assign limit                 = 8 -%}
 {%- assign menu                  = false -%}
 {%- assign message               = section.settings.message -%}
 {%- assign mobile_toggler        = section.settings.mobile_toggler -%}
@@ -18,6 +18,7 @@
 {%- assign padding_bottom        = section.settings.padding_bottom -%}
 {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
 {%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
+{%- assign results_limit         = section.settings.results_limit -%}
 {%- assign rounded_corners       = section.settings.rounded_corners -%}
 {%- assign show_excerpt          = section.settings.show_excerpt -%}
 {%- assign show_navigation       = section.settings.show_navigation -%}
@@ -41,6 +42,10 @@
   {{ "carousel.css" | asset_url | stylesheet_tag }}
 
   {%- assign items = collection.items -%}
+
+  {% unless show_pagination %}
+    {%- assign limit = nil -%}
+  {% endunless %}
 {%- endif -%}
 
 {%- case borders -%}
@@ -132,7 +137,7 @@
             </div>
         {%- endif -%}
 
-              {%- paginate results by limit -%}
+              {%- paginate results by results_limit -%}
                 <div class="search-results">
                   {%- for result in results -%}
                     {%- render 'product-card',
@@ -175,7 +180,7 @@
               <div class="search__carousel carousel carousel__pause" aria-role="Gallery">
                 <input class="carousel__timer" type="hidden" name="hidden" value="{{- timer -}}" aria-hidden="true">
                 <div class="carousel__wrapper">
-                  {%- for item in items limit: 8 -%}
+                  {%- for item in items limit: limit -%}
                     {% assign product = item %}
 
                     <div class="carousel__item">
@@ -207,7 +212,7 @@
 
                 {%- if show_pagination -%}
                   <div class="carousel__pagination hidden" aria-role="Carousel navigation">
-                    {%- for item in items limit: 8 -%}
+                    {%- for item in items limit: limit -%}
                       {%- assign first = forloop.first -%}
                       {%- assign index = forloop.index -%}
 
@@ -324,7 +329,7 @@
       },
       {
         "type": "number",
-        "id": "limit",
+        "id": "results_limit",
         "label": "Pagination limit",
         "min": 6,
         "max": 24,


### PR DESCRIPTION
Some customers don't want to show on an ongoing basis payment icons in the Footer section, so this PR's purpose is to add the show/hide the payment methods icons option to the Footer

![Arc_2024-07-23 18-19-27@2x](https://github.com/user-attachments/assets/b64f19ce-372e-47c1-a37a-16eadf0a07f2)
![Arc_2024-07-23 18-19-49@2x](https://github.com/user-attachments/assets/0f8c669b-e7ee-4e0d-ad87-81593f6cf0c4)
