### PR TITLE
Fix the issue when bundle product images are not displayed

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -117,7 +117,7 @@ body {
   min-height: 100%;
   width: 100%;
   overflow-x: clip;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 body > * {

--- a/assets/hero.css
+++ b/assets/hero.css
@@ -124,9 +124,20 @@
   transform: translate(-50%, -50%);
 }
 
+.hero__vision--video {
+  container: hero-vision / size;
+}
+
 .hero__video {
   pointer-events: none;
-  height: 100%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  height: auto;
+  aspect-ratio: 16 / 9;
+  max-width: none;
+  object-fit: cover;
 }
 
 .hero__text-area--color .hero__content,
@@ -196,17 +207,6 @@
     background: linear-gradient(var(--overlay-direction), var(--background-overlay) 25.94%, var(--background-overlay-00) 100%);
   }
 
-  .hero__video {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    height: auto;
-    aspect-ratio: 16 / 9;
-    max-width: none;
-    object-fit: cover;
-  }
-
   .hero__text-area {
     justify-content: var(--text-justify-content);
     text-align: var(--text-align);
@@ -223,13 +223,6 @@
   }
 }
 
-@media (min-width: 992px) and (min-height: 1080px) {
-  .hero__wrapper-full-height .hero__video {
-    width: auto;
-    height: 100%;
-  }
-}
-
 @media (min-width: 1200px) {
   .hero__container .hero__wrapper {
     padding-right: var(--horizontal-padding);
@@ -237,15 +230,16 @@
   }
 }
 
-@media (min-width: 1920px) {
-  .hero__video {
+@container (aspect-ratio > 16 / 9) {
+  .hero__vision--video .hero__video {
     width: 100%;
+    height: auto;
   }
 }
 
-@media (min-width: 2230px) and (min-height: 1080px) {
-  .hero__wrapper-full-height .hero__video {
-    width: 100%;
-    height: auto;
+@container (aspect-ratio <= 16 / 9) {
+  .hero__vision--video .hero__video {
+    width: auto;
+    height: 100%;
   }
 }

--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -188,7 +188,7 @@
 {%- unless full_width -%}
   <div class="hero__container container">
 {%- endunless -%}
-    <div class="hero__wrapper hero__wrapper-{{- height -}}-height{% if padding_top != blank or padding_top_mobile != blank %} hero__wrapper--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} hero__wrapper--padding-bottom{% endif %} color-{{- color_scheme.id -}}" style="{{- variables | escape -}}">
+    <div class="hero__wrapper{% if padding_top != blank or padding_top_mobile != blank %} hero__wrapper--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} hero__wrapper--padding-bottom{% endif %} color-{{- color_scheme.id -}}" style="{{- variables | escape -}}">
       {%- if full_width -%}
         <div class="hero__container container">
       {%- endif -%}
@@ -220,7 +220,7 @@
         </div>
       {%- endif -%}
 
-      <div class="hero__vision">
+      <div class="hero__vision{% if video_url != blank %} hero__vision--video{%- endif -%}">
         {%- if video_url contains "youtube.com" -%}
           {%- assign video_drop = video_url | split: "?v=" -%}
           {%- assign video_id   = video_drop | last | strip -%}

--- a/sections/product-page.liquid
+++ b/sections/product-page.liquid
@@ -3,6 +3,7 @@
 {%- assign breadcrumbs_collections_label = section.settings.breadcrumbs_collections_label -%}
 {%- assign breadcrumbs_root_label        = section.settings.breadcrumbs_root_label -%}
 {%- assign breadcrumbs_root_url          = section.settings.breadcrumbs_root_url -%}
+{%- assign bundle                        = product.products -%}
 {%- assign color_scheme                  = section.settings.color_scheme -%}
 {%- assign description                   = product.description -%}
 {%- assign images                        = product.images -%}
@@ -114,6 +115,28 @@
 
         {%- else -%}
           <ul class="product-main__gallery">
+            {%- assign unique_image_urls = "" | split: "," -%}
+
+            {%- for item in bundle -%}
+              {%- for image in item.images -%}
+                {% if forloop.first %}
+                  {%- assign current_url = image.url -%}
+
+                  {%- unless unique_image_urls contains current_url -%}
+                    {%- assign unique_image_urls = unique_image_urls | append: current_url -%}
+
+                    <li class="product-main__gallery-item{% if show_border %} product-main__gallery-item--borders{%- endif -%}">
+                      {%- render 'image',
+                          image: image,
+                          loading: 'lazy',
+                          class: 'product-main__gallery-image',
+                          size: 'xl'
+                      -%}
+                    </li>
+                  {%- endunless -%}
+                {% endif %}
+              {%- endfor -%}
+            {%- endfor -%}
             {%- for image in images -%}
               <li class="product-main__gallery-item{% if show_border %} product-main__gallery-item--borders{%- endif -%}">
                 {%- render 'image',

--- a/snippets/root-styles.liquid
+++ b/snippets/root-styles.liquid
@@ -78,6 +78,8 @@
   #cc-main {
     --cc-bg: var(--background-primary);
     --cc-font-family: var(--font-body);
+    --cc-btn-border-radius: var(--border-radius);
+    --cc-modal-border-radius: var(--border-radius-rounded);
 
     --cc-primary-color: var(--color-primary);
     --cc-secondary-color: var(--color-primary);
@@ -88,13 +90,14 @@
 
     --cc-btn-primary-hover-bg: var(--background-accent-hover);
     --cc-btn-primary-hover-border-color: var(--background-accent-hover);
+    --cc-btn-primary-hover-color: var(--color-accent);
 
     --cc-btn-secondary-bg: transparent;
     --cc-btn-secondary-color: var(--color-primary);
     --cc-btn-secondary-border-color: var(--background-accent);
 
-    --cc-btn-secondary-hover-bg: var(--background-accent-secondary-hover);
-    --cc-btn-secondary-hover-border-color: var(--background-accent-secondary-hover);
+    --cc-btn-secondary-hover-bg: var(--background-accent-hover-2);
+    --cc-btn-secondary-hover-border-color: var(--background-accent-hover-2);
     --cc-btn-secondary-hover-color: var(--color-primary);
 
     --cc-cookie-category-block-bg: transparent;


### PR DESCRIPTION
Currently, on the Product page we have the option `Show product images in carousel` for product images and if it is enabled, the product images for a bundle start showing the images of the products included in the bundle + the images of the bundle in a carousel.

This doesn't happen when the option `Show product images in carousel` is disabled, in this scenario, only the images added to the bundle are the ones showing.

This PR is fixing the images' behavior and they are displayed the same if the option `Show product images in carousel` is enabled or disabled.

**Before** (option `Show product images in carousel` is disabled):

![Arc_2024-07-24 15-34-30@2x](https://github.com/user-attachments/assets/8c8f1f80-5093-4611-906a-395511a6d34a)

**Before** (option `Show product images in carousel` is enabled):

![Arc_2024-07-24 15-32-53@2x](https://github.com/user-attachments/assets/c8b26629-fdec-4cb6-9a11-3cbce1a6c669)

**After** (option `Show product images in carousel` is disabled):

![Arc_2024-07-24 15-33-44@2x](https://github.com/user-attachments/assets/7b2b1177-7529-41de-af49-a9815ac12721)

**After** (option `Show product images in carousel` is enabled):

![Arc_2024-07-24 15-32-53@2x](https://github.com/user-attachments/assets/c8b26629-fdec-4cb6-9a11-3cbce1a6c669)
