### PR TITLE
Remove stripping HTML and truncating of product excerpts

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -3,13 +3,11 @@ class Main {
     this.body = body;
 
     this.selector = {
-      image: ".focal-image",
-      excerpt: ".product-card__description"
+      image: ".focal-image"
     }
 
     this.modifier = {
-      loaded: "loaded",
-      truncated: "truncated"
+      loaded: "loaded"
     }
 
     this.data = {
@@ -21,59 +19,27 @@ class Main {
       bodyHeight: '--body-height'
     }
 
-    this.cssProp = {
-      maxHeight: 'max-height',
-      paddingTop: 'padding-top',
-      paddingBottom: 'padding-bottom'
-    }
-
     this.focalImageTimeout;
   }
 
   init() {
     if (!this.body) return false;
 
-    this.elements();
     this.events();
-  }
-
-  elements() {
-    this.excerpts = document.querySelectorAll(this.selector.excerpt);
   }
 
   events() {
     this.getBodyHeight();
     this.setLoadedClass();
     this.focalImages();
-    this.setTruncationClass();
 
     window.addEventListener("resize", this.getBodyHeight.bind(this));
-    window.addEventListener("resize", this.setTruncationClass.bind(this));
   }
 
   getBodyHeight() {
     const height = this.body.getBoundingClientRect().height
 
     this.setCssVar(this.cssVar.bodyHeight, height);
-  }
-
-  // set class for truncation product card description
-  setTruncationClass() {
-    if (!this.excerpts.length) return false;
-
-    const styles = window.getComputedStyle(this.excerpts[0]),
-          paddingTop = parseInt(styles.getPropertyValue(this.cssProp.paddingTop)),
-          paddingBottom = parseInt(styles.getPropertyValue(this.cssProp.paddingBottom)),
-          maxHeight = parseInt(styles.getPropertyValue(this.cssProp.maxHeight)),
-          minHeight = maxHeight / 2 + paddingBottom + paddingTop;
-
-    this.excerpts.forEach(excerpt => {
-      const height = excerpt.getBoundingClientRect().height
-
-      height > minHeight
-        ? excerpt.classList.add(this.modifier.truncated)
-        : excerpt.classList.remove(this.modifier.truncated)
-    })
   }
 
   setCssVar(key, val) {

--- a/assets/product-card.css
+++ b/assets/product-card.css
@@ -73,39 +73,10 @@
 .product-card__description {
   padding: 4px 0 8px;
   flex-grow: 0;
-  overflow: hidden;
-  max-height: 130px;
 }
 
 .product-card__description:last-child {
   padding-bottom: 0;
-}
-
-.product-card__description.truncated {
-  position: relative;
-  flex-grow: 1;
-}
-
-.product-card__description.truncated + .product-card__price-info {
-  flex-grow: 0;
-}
-
-.product-card__description.truncated:after {
-  content: "";
-  display: block;
-  width: 100%;
-  height: 60px;
-  background: linear-gradient(to top, var(--background-primary) 0%, var(--background-primary) 30%, var(--background-primary-00) 100%);
-  position: absolute;
-  bottom: 0;
-  left: 0;
-}
-
-.product-card__meta .product-card__description dt,
-.product-card__meta .product-card__description dd,
-.product-card__meta .product-card__description li,
-.product-card__meta .product-card__description li li {
-  font-size: inherit;
 }
 
 .product-card__price-info {

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -51,7 +51,7 @@
   {%- assign id      = product.id -%}
   {%- assign url     = product.url -%}
   {%- assign name    = product.name -%}
-  {%- assign excerpt = product.description -%}
+  {%- assign excerpt = product.excerpt -%}
   {%- assign price   = product | product_price -%}
   {%- assign period  = product | product_price_label -%}
 {%- else -%}
@@ -102,7 +102,7 @@
     </h3>
 
     {%- if excerpt != blank and show_excerpt -%}
-      <div class="product-card__description bq-content rx-content">{{- excerpt -}}</div>
+      <div class="product-card__description">{{- excerpt -}}</div>
     {%- endif -%}
 
     {%- if price != blank and period != blank -%}

--- a/snippets/root-styles.liquid
+++ b/snippets/root-styles.liquid
@@ -51,7 +51,7 @@
       --border-radius-rounded: 8px;
       --border-radius-checkbox: 4px;
     {% elsif settings.corner_radius == 'fully_round' %}
-      --border-radius: 50px;
+      --border-radius: 25px;
       --border-radius-rounded: 8px;
       --border-radius-checkbox: 4px;
     {% endif %}


### PR DESCRIPTION
Due to a new product excerpt field [already available on the production](https://github.com/booqable/booqable/pull/11138), so all the stuff that temporarily solved the issue of not-so-beautiful product descriptions in product cards, and its stripping html and truncating on the theme side should be removed now.

![Arc_2024-07-30 16-02-02@2x](https://github.com/user-attachments/assets/aec44886-791f-4367-8447-a8b5efd6ecc4)
![Teampaper_2024-07-30 16-03-30@2x](https://github.com/user-attachments/assets/a656a666-efd4-4ac2-9caf-f04d5ba83b2c)
