### PR TITLE
Fix the pricing layout if a label is too long

### DIFF
--- a/assets/product-card.css
+++ b/assets/product-card.css
@@ -91,6 +91,7 @@
 
 .product-card__price-wrapper {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-end;
 }
 

--- a/sections/title.liquid
+++ b/sections/title.liquid
@@ -109,7 +109,7 @@
           </h2>
 
           <div class="title__description text-medium bq-content rx-content">
-            {{- custom_description | default: collection.description | default: page_description -}}
+            {{- custom_description | default: collection.description -}}
           </div>
         </div>
   {%- if full_width -%}


### PR DESCRIPTION
Fix the issue when you add a bit long pricing structure label, it will shrink the pricing and break the layout.

**Before:**
![Arc_2024-08-05 13-12-45@2x](https://github.com/user-attachments/assets/4931790a-444f-44be-9ec5-d0f8145859c3)


**After:**
![Arc_2024-08-05 13-12-31@2x](https://github.com/user-attachments/assets/d4e8e5ac-facb-4891-9e9e-09df8d901e58)
