### PR TITLE
Implement `Accept invitation` page

### DIFF
--- a/sections/accept-invitation-form.liquid
+++ b/sections/accept-invitation-form.liquid
@@ -1,18 +1,19 @@
 {{ "account.css" | asset_url | stylesheet_tag }}
 
-{%- assign button_primary_label  = section.settings.button_primary_label | default: "Change my password" -%}
+{%- assign button_primary_label  = section.settings.button_primary_label | default: "Accept invite" -%}
 {%- assign color_scheme          = section.settings.color_scheme -%}
-{%- assign description           = section.settings.description -%}
 {%- assign image                 = section.settings.image -%}
-{%- assign padding_top           = section.settings.padding_top -%}
 {%- assign padding_bottom        = section.settings.padding_bottom -%}
-{%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
 {%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
-{%- assign password_label        = section.settings.password_label | default: "New password" | append: "*" -%}
-{%- assign password_confirmation = section.settings.password_confirmation | default: "Confirm new password" | append: "*" -%}
+{%- assign padding_top           = section.settings.padding_top -%}
+{%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
+{%- assign password_confirmation = section.settings.password_confirmation | default: "Confirm new password" -%}
+{%- assign password_label        = section.settings.password_label | default: "New password" -%}
+{%- assign please_enter_password = section.settings.please_enter_password -%}
 {%- assign rounded_corners       = section.settings.rounded_corners -%}
 {%- assign show_border           = section.settings.show_border -%}
-{%- assign title                 = section.settings.title -%}
+{%- assign success_link_label    = section.settings.success_link_label -%}
+{%- assign you_are_invited       = section.settings.you_are_invited -%}
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
@@ -71,27 +72,41 @@
 >
   <div class="account__container container">
     <div class="account__inner{% if show_border %} account__inner--border{%- endif -%}">
-      <h3 class="account__title text-center">
-        {{- title | default: "Change your password" -}}
-      </h3>
-
-      {%- if description != blank -%}
-        <div class="account__divider text-center">
-          {{- description -}}
-        </div>
+      {%- if alert -%}
+        <div class="account__alert account__alert--danger">{{ alert }}</div>
       {%- endif -%}
 
-      <hr class="account__separator">
+      {%- if notice -%}
+        <div class="account__alert account__alert--info">{{ notice }}</div>
+      {%- endif -%}
 
-      {%- form 'edit_password' -%}
-        {%- render 'form-password-session-pages',
-            form: form,
-            form_name: "edit_password",
-            password_label: password_label,
-            password_confirmation_label: password_confirmation,
-            button_label: button_primary_label
-        -%}
-      {%- endform -%}
+      {%- if success_link_url -%}
+        <a href="{{ success_link_url }}">{{ success_link_label }}</a>
+      {%- endif -%}
+
+      {%- unless hide_form -%}
+        {% if you_are_invited or please_enter_password %}
+          <div class="account__alert account__alert--info">
+            {% if you_are_invited %}
+              <p>{{ you_are_invited }}</p>
+            {% endif %}
+
+            {% if please_enter_password %}
+              <p>{{ please_enter_password }}</p>
+            {% endif %}
+          </div>
+        {% endif %}
+
+        {%- form 'accept_invitation' -%}
+          {%- render 'form-password-session-pages',
+              form: form,
+              form_name: "accept_invitation",
+              password_label: password_label,
+              password_confirmation_label: password_confirmation,
+              button_label: button_primary_label
+          -%}
+        {%- endform -%}
+      {%- endunless -%}
     </div>
   </div>
   {%- if image.url != blank -%}
@@ -107,11 +122,11 @@
 
 {% schema %}
   {
-    "name": "Edit password form",
+    "name": "Accept invitation form",
     "important": true,
     "unique": true,
     "tag": "section",
-    "templates": ["edit-password"],
+    "templates": ["accept-invitation"],
     "settings": [
       {
         "type": "header",
@@ -125,13 +140,13 @@
       },
       {
         "type": "text",
-        "id": "title",
-        "label": "Title"
+        "id": "you_are_invited",
+        "label": "Accept invitation title"
       },
       {
         "type": "text",
-        "id": "description",
-        "label": "Description"
+        "id": "please_enter_password",
+        "label": "Password instructions"
       },
       {
         "type": "text",
@@ -142,6 +157,11 @@
         "type": "text",
         "id": "password_confirmation",
         "label": "Password confirmation label"
+      },
+      {
+        "type": "text",
+        "id": "success_link_label",
+        "label": "Success link label"
       },
       {
         "type": "image_picker",

--- a/sections/login-form.liquid
+++ b/sections/login-form.liquid
@@ -145,7 +145,6 @@
             type="submit"
             class="account__button button button--primary button--large"
             name="commit"
-            data-disable-with="Log in"
           >
             {{- button_login_label | default: "Log in" -}}
           </button>

--- a/sections/register-form.liquid
+++ b/sections/register-form.liquid
@@ -240,7 +240,6 @@
           type="submit"
           class="account__button button button--primary button--large"
           name="commit"
-          data-disable-with="Sign up"
         >
           {{- button_sign_up_label | default: "Sign up" -}}
         </button>

--- a/sections/register-form.liquid
+++ b/sections/register-form.liquid
@@ -132,7 +132,6 @@
           <input
             value="{{- form.email -}}"
             class="account-fieldset__input"
-            autofocus="autofocus"
             autocomplete="email"
             type="email"
             name="user[email]"

--- a/sections/register-form.liquid
+++ b/sections/register-form.liquid
@@ -12,8 +12,8 @@
 {%- assign email_label                              = section.settings.email_label -%}
 {%- assign image                                    = section.settings.image -%}
 {%- assign name_label                               = section.settings.name_label -%}
-{%- assign password_label                           = section.settings.password_label -%}
-{%- assign password_confirmation_label              = section.settings.password_confirmation_label -%}
+{%- assign password_label                           = section.settings.password_label | default: "Password" | append: "*" -%}
+{%- assign password_confirmation_label              = section.settings.password_confirmation_label | default: "Password confirmation" | append: "*" -%}
 {%- assign padding_top                              = section.settings.padding_top -%}
 {%- assign padding_bottom                           = section.settings.padding_bottom -%}
 {%- assign padding_top_mobile                       = section.settings.padding_top_mobile -%}
@@ -143,39 +143,13 @@
           </div>
         </div>
 
-        <div class="account-fieldset__block account__divider--small{% if form.errors.password %} account-fieldset--error{%- endif -%}">
-          <label for="user_password" class="account-fieldset__label">
-            {{- password_label | default: "Password" | append: "*" -}}
-          </label>
-
-          <input
-            class="account-fieldset__input"
-            autocomplete="new-password"
-            type="password"
-            name="user[password]"
-            id="user_password">
-
-          <div class="account__error-message">
-            {{- form.errors.password -}}
-          </div>
-        </div>
-
-        <div class="account-fieldset__block{% if form.errors.password_confirmation %} account-fieldset--error{%- endif -%}">
-          <label for="user_password_confirmation" class="account-fieldset__label">
-            {{- password_confirmation_label | default: "Password confirmation" | append: "*" -}}
-          </label>
-
-          <input
-            class="account-fieldset__input"
-            autocomplete="new-password"
-            type="password"
-            name="user[password_confirmation]"
-            id="user_password_confirmation">
-
-          <div class="account__error-message">
-            {{- form.errors.password_confirmation -}}
-          </div>
-        </div>
+        {%- render 'form-password-session-pages',
+            form: form,
+            form_name: "register",
+            password_label: password_label,
+            password_confirmation_label: password_confirmation_label,
+            button_label: nil
+        -%}
 
         <div class="account__type account__divider{% if form.errors.customer %} account-fieldset--error{%- endif -%}">
           <span class="account-fieldset__static-label">

--- a/sections/reset-password-form.liquid
+++ b/sections/reset-password-form.liquid
@@ -112,7 +112,6 @@
           type="submit"
           class="account__button button button--primary button--large"
           name="commit"
-          data-disable-with="Send me reset password instructions"
         >
           {{- button_primary_label | default: "Reset password" -}}
         </button>

--- a/snippets/form-password-session-pages.liquid
+++ b/snippets/form-password-session-pages.liquid
@@ -1,6 +1,6 @@
 {% comment %}
 
-  This snippet is using for rendering the form on Edit password, Accept invitation and Reset password pages.
+  This snippet is using for rendering the form password inputs on Edit password, Accept invitation and Register pages.
 
   form_name - "string" optional, the name of the form
   password_label - "string" required, the label of the first field

--- a/snippets/form-password-session-pages.liquid
+++ b/snippets/form-password-session-pages.liquid
@@ -68,7 +68,6 @@
       type="submit"
       class="account__button button button--primary button--large"
       name="commit"
-      data-disable-with="{{- button_label -}}"
     >
       {{- button_label -}}
     </button>

--- a/snippets/form-password-session-pages.liquid
+++ b/snippets/form-password-session-pages.liquid
@@ -1,0 +1,76 @@
+{% comment %}
+
+  This snippet is using for rendering the form on Edit password, Accept invitation and Reset password pages.
+
+  form_name - "string" optional, the name of the form
+  password_label - "string" required, the label of the first field
+  password_confirmation_label - "string" required, the label of the second field
+  button_label - "string" required
+
+  Usage:
+
+  {%- render 'form-password-session-pages',
+      form: form,
+      form_name: your_id,
+      password_label: your_id,
+      password_confirmation_label: your_id,
+      button_label: your_id
+  -%}
+
+{% endcomment %}
+
+{%- if password_label != blank -%}
+  <div class="account-fieldset__block account__divider--small{% if form.errors.password %} account-fieldset--error{%- endif -%}">
+    <label for="user_password" class="account-fieldset__label">
+      {{- password_label -}}
+    </label>
+
+    <input
+      value="{{- form.password -}}"
+      class="account-fieldset__input"
+      {% unless form_name == "register" %}
+        autofocus="autofocus"
+      {% endunless %}
+      autocomplete="new-password"
+      type="password"
+      name="user[password]"
+      id="user_password">
+
+    <div class="account__error-message">
+      {{- form.errors.password -}}
+    </div>
+  </div>
+{%- endif -%}
+
+{%- if password_confirmation_label != blank -%}
+  <div class="account-fieldset__block{% if form.errors.password_confirmation %} account-fieldset--error{%- endif -%}">
+    <label for="user_password_confirmation" class="account-fieldset__label">
+      {{- password_confirmation_label -}}
+    </label>
+
+    <input
+      value="{{- form.password_confirmation -}}"
+      class="account-fieldset__input"
+      autocomplete="new-password"
+      type="password"
+      name="user[password_confirmation]"
+      id="user_password_confirmation">
+
+    <div class="account__error-message">
+      {{- form.errors.password_confirmation -}}
+    </div>
+  </div>
+{%- endif -%}
+
+{%- if button_label != blank -%}
+  <div class="actions">
+    <button
+      type="submit"
+      class="account__button button button--primary button--large"
+      name="commit"
+      data-disable-with="{{- button_label -}}"
+    >
+      {{- button_label -}}
+    </button>
+  </div>
+{%- endif -%}

--- a/snippets/form-password-session-pages.liquid
+++ b/snippets/form-password-session-pages.liquid
@@ -1,6 +1,6 @@
 {% comment %}
 
-  This snippet is using for rendering the form password inputs on Edit password, Accept invitation and Register pages.
+  This snippet is using for rendering the form input password fields on Edit password, Accept invitation and Register pages.
 
   form_name - "string" optional, the name of the form
   password_label - "string" required, the label of the first field

--- a/snippets/form.liquid
+++ b/snippets/form.liquid
@@ -45,7 +45,6 @@
 
       <input
         value="{{- form.author -}}"
-        placeholder=" "
         class="form__input"
         autocomplete="author"
         type="text"
@@ -66,7 +65,6 @@
 
       <input
         value="{{- form.email -}}"
-        placeholder=" "
         class="form__input"
         autocomplete="email"
         type="email"
@@ -87,7 +85,6 @@
 
       <textarea
         value=" "
-        placeholder=" "
         class="form__textarea"
         name="form[body]"
         id="body"

--- a/templates/accept-invitation.json
+++ b/templates/accept-invitation.json
@@ -1,0 +1,30 @@
+{
+  "name": "Accept invitation",
+  "layout": "session",
+  "sections": {
+    "accept-invitation-form": {
+      "type": "accept-invitation-form",
+      "blocks": {},
+      "settings": {
+        "button_primary_label": "",
+        "color_scheme": "set-5",
+        "image": "",
+        "padding_bottom": "large",
+        "padding_bottom_mobile": "large",
+        "padding_top": "large",
+        "padding_top_mobile": "large",
+        "password_confirmation": "",
+        "password_label": "",
+        "please_enter_password": "If you want to continue, please enter your password below.",
+        "rounded_corners": "none",
+        "show_border": true,
+        "success_link_label": "Continue to the store",
+        "you_are_invited": "You've been invited to create an account."
+      }
+    }
+  },
+  "order": ["accept-invitation-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
+}

--- a/templates/adrenaline/accept-invitation.json
+++ b/templates/adrenaline/accept-invitation.json
@@ -1,0 +1,30 @@
+{
+  "name": "Accept invitation",
+  "layout": "session",
+  "sections": {
+    "accept-invitation-form": {
+      "type": "accept-invitation-form",
+      "blocks": {},
+      "settings": {
+        "button_primary_label": "",
+        "color_scheme": "set-1",
+        "image": "booqable://assets/image-curvilinear-lines.png",
+        "padding_bottom": "large",
+        "padding_bottom_mobile": "medium",
+        "padding_top": "large",
+        "padding_top_mobile": "medium",
+        "password_confirmation": "",
+        "password_label": "",
+        "please_enter_password": "If you want to continue, please enter your password below.",
+        "rounded_corners": "large",
+        "show_border": true,
+        "success_link_label": "Continue to the store",
+        "you_are_invited": "You've been invited to create an account."
+      }
+    }
+  },
+  "order": ["accept-invitation-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
+}

--- a/templates/adventure/accept-invitation.json
+++ b/templates/adventure/accept-invitation.json
@@ -1,0 +1,30 @@
+{
+  "name": "Accept invitation",
+  "layout": "session",
+  "sections": {
+    "accept-invitation-form": {
+      "type": "accept-invitation-form",
+      "blocks": {},
+      "settings": {
+        "button_primary_label": "",
+        "color_scheme": "set-5",
+        "image": "booqable://assets/image-background-mountains.png",
+        "padding_bottom": "large",
+        "padding_bottom_mobile": "large",
+        "padding_top": "large",
+        "padding_top_mobile": "large",
+        "password_confirmation": "",
+        "password_label": "",
+        "please_enter_password": "If you want to continue, please enter your password below.",
+        "rounded_corners": "small",
+        "show_border": true,
+        "success_link_label": "Continue to the store",
+        "you_are_invited": "You've been invited to create an account."
+      }
+    }
+  },
+  "order": ["accept-invitation-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
+}

--- a/templates/daredevil/accept-invitation.json
+++ b/templates/daredevil/accept-invitation.json
@@ -1,0 +1,30 @@
+{
+  "name": "Accept invitation",
+  "layout": "session",
+  "sections": {
+    "accept-invitation-form": {
+      "type": "accept-invitation-form",
+      "blocks": {},
+      "settings": {
+        "button_primary_label": "",
+        "color_scheme": "set-5",
+        "image": "booqable://assets/image-curvilinear-lines.png",
+        "padding_bottom": "large",
+        "padding_bottom_mobile": "large",
+        "padding_top": "large",
+        "padding_top_mobile": "large",
+        "password_confirmation": "",
+        "password_label": "",
+        "please_enter_password": "If you want to continue, please enter your password below.",
+        "rounded_corners": "none",
+        "show_border": true,
+        "success_link_label": "Continue to the store",
+        "you_are_invited": "You've been invited to create an account."
+      }
+    }
+  },
+  "order": ["accept-invitation-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
+}


### PR DESCRIPTION
This PR goal is to implement a new Accept invitation page into all theme variants, and slightly refactor the code:
remove `data-disable-with` attribute from everywhere, and move form input password fields code to snippet.

Since this feature doesn't work on the production yet I can't provide screenshots (((