### PR TITLE
Fix blank space at the end of a page if there is only 1 section on the page

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -151,6 +151,11 @@ body > * {
   flex-grow: 1;
 }
 
+#main > section:only-child > [class*="__wrapper"],
+#main > section:only-child > [class^="__wrapper"] {
+  flex-grow: 1;
+}
+
 .preview-app #main:has(section:only-child) {
   display: block;
 }

--- a/sections/title.liquid
+++ b/sections/title.liquid
@@ -10,7 +10,6 @@
 {%- assign padding_bottom          = section.settings.padding_bottom -%}
 {%- assign padding_top_mobile      = section.settings.padding_top_mobile -%}
 {%- assign padding_bottom_mobile   = section.settings.padding_bottom_mobile -%}
-{%- assign page_title              = page_title | split: " | " | first | remove: ":"-%}
 {%- assign show_transition_bottom  = section.settings.show_transition_bottom -%}
 {%- assign show_transition_top     = section.settings.show_transition_top -%}
 {%- assign tag                     = section.settings.tag -%}
@@ -105,7 +104,7 @@
           {%- endif -%}
 
           <h2 class="title__heading h4">
-            {{- custom_title | default: collection.title | default: page_title -}}
+            {{- custom_title | default: collection.title -}}
           </h2>
 
           <div class="title__description text-medium bq-content rx-content">

--- a/templates/adrenaline/cart.json
+++ b/templates/adrenaline/cart.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-5",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Cart",
         "full_width": false,
         "image": "",
         "padding_bottom": "large",

--- a/templates/adrenaline/list-collections.json
+++ b/templates/adrenaline/list-collections.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-5",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Collections",
         "full_width": false,
         "image": "",
         "padding_bottom": "large",

--- a/templates/adrenaline/page.contact.json
+++ b/templates/adrenaline/page.contact.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-5",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Contacts",
         "full_width": false,
         "image": "",
         "padding_bottom": "large",

--- a/templates/adrenaline/page.json
+++ b/templates/adrenaline/page.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-5",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Page",
         "full_width": false,
         "image": "",
         "padding_bottom": "large",

--- a/templates/adrenaline/search.json
+++ b/templates/adrenaline/search.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-5",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Search",
         "full_width": false,
         "image": "",
         "padding_bottom": "large",

--- a/templates/adventure/cart.json
+++ b/templates/adventure/cart.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Cart",
         "full_width": true,
         "image": "booqable://assets/image-background-mountains.png",
         "padding_bottom": "large",

--- a/templates/adventure/list-collections.json
+++ b/templates/adventure/list-collections.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Collections",
         "full_width": true,
         "image": "booqable://assets/image-background-mountains.png",
         "padding_bottom": "large",

--- a/templates/adventure/page.contact.json
+++ b/templates/adventure/page.contact.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Contacts",
         "full_width": true,
         "image": "booqable://assets/image-background-mountains.png",
         "padding_bottom": "large",

--- a/templates/adventure/page.json
+++ b/templates/adventure/page.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Page",
         "full_width": true,
         "image": "booqable://assets/image-background-mountains.png",
         "padding_bottom": "large",

--- a/templates/adventure/search.json
+++ b/templates/adventure/search.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Search",
         "full_width": true,
         "image": "booqable://assets/image-background-mountains.png",
         "padding_bottom": "large",

--- a/templates/cart.json
+++ b/templates/cart.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Cart",
         "full_width": true,
         "image": "",
         "padding_bottom": "large",

--- a/templates/daredevil/cart.json
+++ b/templates/daredevil/cart.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Cart",
         "full_width": true,
         "image": "booqable://assets/image-curvilinear-lines.png",
         "padding_bottom": "large",

--- a/templates/daredevil/list-collections.json
+++ b/templates/daredevil/list-collections.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Collections",
         "full_width": true,
         "image": "booqable://assets/image-curvilinear-lines.png",
         "padding_bottom": "large",

--- a/templates/daredevil/page.contact.json
+++ b/templates/daredevil/page.contact.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Contacts",
         "full_width": true,
         "image": "booqable://assets/image-curvilinear-lines.png",
         "padding_bottom": "large",

--- a/templates/daredevil/page.json
+++ b/templates/daredevil/page.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Page",
         "full_width": true,
         "image": "booqable://assets/image-curvilinear-lines.png",
         "padding_bottom": "large",

--- a/templates/daredevil/search.json
+++ b/templates/daredevil/search.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Search",
         "full_width": true,
         "image": "booqable://assets/image-curvilinear-lines.png",
         "padding_bottom": "large",

--- a/templates/explore/cart.json
+++ b/templates/explore/cart.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Cart",
         "full_width": true,
         "image": "",
         "padding_bottom": "large",

--- a/templates/explore/list-collections.json
+++ b/templates/explore/list-collections.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Collections",
         "full_width": true,
         "image": "",
         "padding_bottom": "large",

--- a/templates/explore/page.contact.json
+++ b/templates/explore/page.contact.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Contacts",
         "full_width": true,
         "image": "",
         "padding_bottom": "large",

--- a/templates/explore/search.json
+++ b/templates/explore/search.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Search",
         "full_width": true,
         "image": "",
         "padding_bottom": "large",

--- a/templates/flow/cart.json
+++ b/templates/flow/cart.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Cart",
         "full_width": true,
         "image": "",
         "padding_bottom": "large",

--- a/templates/flow/list-collections.json
+++ b/templates/flow/list-collections.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Collections",
         "full_width": true,
         "image": "",
         "padding_bottom": "large",

--- a/templates/flow/page.contact.json
+++ b/templates/flow/page.contact.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Contacts",
         "full_width": true,
         "image": "",
         "padding_bottom": "large",

--- a/templates/flow/page.json
+++ b/templates/flow/page.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Page",
         "full_width": true,
         "image": "",
         "padding_bottom": "large",

--- a/templates/flow/search.json
+++ b/templates/flow/search.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Search",
         "full_width": true,
         "image": "",
         "padding_bottom": "large",

--- a/templates/list-collections.json
+++ b/templates/list-collections.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Collections",
         "full_width": true,
         "image": "",
         "padding_bottom": "large",

--- a/templates/page.contact.json
+++ b/templates/page.contact.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Contacts",
         "full_width": true,
         "image": "",
         "padding_bottom": "large",

--- a/templates/page.json
+++ b/templates/page.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Page",
         "full_width": true,
         "image": "",
         "padding_bottom": "large",

--- a/templates/search.json
+++ b/templates/search.json
@@ -8,7 +8,7 @@
       "settings": {
         "color_scheme": "set-4",
         "custom_description": "",
-        "custom_title": "",
+        "custom_title": "Search",
         "full_width": true,
         "image": "",
         "padding_bottom": "large",


### PR DESCRIPTION
This PR's purpose is to fix blank space between a single section on page and the footer if browsing on big screens

Before:
![Arc_2024-09-02 19-37-39@2x](https://github.com/user-attachments/assets/e380f73b-e74b-4153-a267-3ffb8790e55b)


After:
![Arc_2024-09-02 19-38-08@2x](https://github.com/user-attachments/assets/80bf4f08-a23c-4b0d-a802-7e0e17463565)
