### PR TITLE
Fix sidebar menu issue when it is not showing

### DIFF
--- a/sections/collection-page.liquid
+++ b/sections/collection-page.liquid
@@ -30,6 +30,7 @@
 
   {%- if menu != blank -%}
     {%- assign menu = true -%}
+    {%- break -%}
   {%- endif -%}
 {%- endfor -%}
 

--- a/sections/search.liquid
+++ b/sections/search.liquid
@@ -35,6 +35,7 @@
 
   {%- if menu != blank -%}
     {%- assign menu = true -%}
+    {%- break -%}
   {%- endif -%}
 {%- endfor -%}
 


### PR DESCRIPTION
This PR aims to fix the sidebar issue when it is not showing if the menu is not chosen in the last block on Collection/Search pages

![Arc_2024-09-04 13-14-41@2x](https://github.com/user-attachments/assets/a100b9ca-34e5-44be-9bf1-58d7e23c37c0)
