### PR TITLE
Add a rental period next to the price on product page

### DIFF
--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -41,6 +41,10 @@
   margin: 0 0 20px;
 }
 
+.product-main__price-separator {
+  margin: 0 5px;
+}
+
 .product-main__price bq-product-price {
   font-size: 24px;
   font-family: var(--font-body);

--- a/sections/product-page.liquid
+++ b/sections/product-page.liquid
@@ -28,6 +28,7 @@
 {%- assign bundle_items                  = product | bundle_items -%}
 {%- assign quantity                      = product | product_button -%}
 {%- assign price                         = product | product_price -%}
+{%- assign period                        = product | product_price_label -%}
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
@@ -152,7 +153,17 @@
 
       <div class="product-main__info">
         <h1 class="product-main__title">{{- title -}}</h1>
-        <div class="product-main__price">{{- price -}}</div>
+
+        {%- if price != blank -%}
+          <div class="product-main__price">
+            {{- price -}}
+
+            {%- if period != blank -%}
+              <span class="product-main__price-separator">/</span>
+              {{- period -}}
+            {%- endif -%}
+          </div>
+        {%- endif -%}
 
         {%- if description != blank -%}
           <div class="product-main__description bq-content rx-content">{{- description -}}</div>


### PR DESCRIPTION
Currently, the product page doesn't provide any information about the rental period, so this PR's goal is to add it next to the price

Before:
![Arc 2024-09-20 16 21 44](https://github.com/user-attachments/assets/0cbd9e8a-f1e9-4286-9d59-ec24a64f2828)


After:
![Arc 2024-09-20 16 21 16](https://github.com/user-attachments/assets/ab96dd01-6fa0-4cc5-8c61-2d50736cb1c5)
