### PR TITLE
Fix the border-radius of locations in a new date picker

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -452,7 +452,6 @@ div[data-tippy-root]:has([data-tid="Mini cart"] [class*="DetailContainer-"] > [c
   border-bottom-left-radius: var(--border-radius-rounded) !important;
 }
 
-div[data-tid="Modal"][class*="Container-"]:has([class*="Select__control"]) [class*="Select__control"],
 div[data-tippy-root]:has([data-tid="Mini cart"] [class*="DetailContainer-"] > [class*="Quantity-"]) [class*="QuantityButton"]:last-child {
   border-top-right-radius: var(--border-radius-rounded) !important;
   border-bottom-right-radius: var(--border-radius-rounded) !important;
@@ -464,11 +463,16 @@ div[data-tippy-root]:has([class*="tippy-content"] [class*="DayPicker-wrapper"] [
 }
 
 div[data-tid="Modal"][class*="Container-"],
+div[data-tid="Modal"][class*="Container-"]:has([class*="Select__control"]) [class*="Select__control"],
 div[data-tid="Modal"]:has(> div[class*="Body-"] form > div > div) div[class*="Body-"] form > div > div,
 div[data-tid="Modal"] div[data-tid="Start and stop location dropdown"][class*="Container-"] [class*="Select__control"],
 div[data-tippy-root]:has([data-tid="Mini cart"] [data-tid*="Select dates"] > [class*="DatesBase-"] > [class*="Dates"]) [class*="DatesBase-"] > [class*="Dates"],
 div[data-tippy-root]:has([class*="tippy-content"] [class*="DayPicker-wrapper"] [class*="DayPicker-NavBar"]) [class*="tippy-content"] > div > [class*="Content"] > [class*="Inner"] {
   border-radius: var(--border-radius-rounded) !important;
+}
+
+div[data-tid="Modal actions"] button {
+  border-radius: var(--border-radius) !important;
 }
 
 @media (min-width: 576px) {


### PR DESCRIPTION
This PR aims to fix the `border-radius` of location pickers in a new date picker

Before:
![image](https://github.com/user-attachments/assets/988e93d9-ecf0-4b5a-b54a-6cf6828d5451)


After:
![Arc 2024-09-26 16 21 14](https://github.com/user-attachments/assets/bb7387c6-8545-4e6a-bb40-c2e529f1e1f0)

