### PR TITLE
Move product card settings, add color schemes of product cards

### DIFF
--- a/assets/product-card.css
+++ b/assets/product-card.css
@@ -4,7 +4,6 @@
   position: relative;
   width: 100%;
   overflow: hidden;
-  color: var(--color-secondary);
 }
 
 .product-card--full-border,
@@ -18,6 +17,10 @@
   overflow: hidden;
   position: relative;
   background: var(--background-primary);
+}
+
+.product-card__vision--white {
+  background: var(--color-white);
 }
 
 .product-card__vision .product-card__link {
@@ -60,6 +63,8 @@
 
 .product-card--full-border .product-card__meta {
   padding: 15px;
+  background: var(--background-primary);
+  color: var(--color-secondary);
 }
 
 .product-card__title {

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -60,6 +60,11 @@
           }
         }
       },
+      "card_borders": "image",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "large",
       "corner_radius": "fully_round",
       "font_weight_h1": "600",
       "font_weight_h2": "700",
@@ -168,6 +173,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "open-sans",
@@ -234,6 +240,11 @@
           }
         }
       },
+      "card_borders": "image",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "small",
       "corner_radius": "rounded",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -342,6 +353,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "roboto",
@@ -408,6 +420,11 @@
           }
         }
       },
+      "card_borders": "full",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "none",
       "corner_radius": "square",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -517,6 +534,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
@@ -583,6 +601,11 @@
           }
         }
       },
+      "card_borders": "image",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "large",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -692,6 +715,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "open-sans",
@@ -758,6 +782,11 @@
           }
         }
       },
+      "card_borders": "full",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "small",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -867,6 +896,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
@@ -933,6 +963,11 @@
           }
         }
       },
+      "card_borders": "full",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "none",
       "corner_radius": "square",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -1042,6 +1077,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
@@ -1108,6 +1144,11 @@
           }
         }
       },
+      "card_borders": "image",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "none",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -1216,6 +1257,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "open-sans",
@@ -1282,6 +1324,11 @@
           }
         }
       },
+      "card_borders": "full",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "small",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -1391,6 +1438,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "dm-sans",
@@ -1457,6 +1505,11 @@
           }
         }
       },
+      "card_borders": "image",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "none",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -1565,6 +1618,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
@@ -1631,6 +1685,11 @@
           }
         }
       },
+      "card_borders": "full",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "none",
       "corner_radius": "square",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -1739,6 +1798,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
@@ -1805,6 +1865,11 @@
           }
         }
       },
+      "card_borders": "full",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "small",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -1914,6 +1979,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "roboto",
@@ -1980,6 +2046,11 @@
           }
         }
       },
+      "card_borders": "image",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "large",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -2089,6 +2160,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "open-sans",
@@ -2155,6 +2227,11 @@
           }
         }
       },
+      "card_borders": "image",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "none",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -2264,6 +2341,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "open-sans",
@@ -2330,6 +2408,11 @@
           }
         }
       },
+      "card_borders": "full",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "small",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -2439,6 +2522,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
@@ -2505,6 +2589,11 @@
           }
         }
       },
+      "card_borders": "image",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "large",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -2614,6 +2703,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "poppins",
@@ -2680,6 +2770,11 @@
           }
         }
       },
+      "card_borders": "image",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "none",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -2789,6 +2884,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
@@ -2855,6 +2951,11 @@
           }
         }
       },
+      "card_borders": "image",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "large",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -2964,6 +3065,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "baloo-2",
@@ -3030,6 +3132,11 @@
           }
         }
       },
+      "card_borders": "full",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "small",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -3138,6 +3245,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
@@ -3204,6 +3312,11 @@
           }
         }
       },
+      "card_borders": "full",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "small",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -3313,6 +3426,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
@@ -3379,6 +3493,11 @@
           }
         }
       },
+      "card_borders": "image",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "large",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -3488,6 +3607,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "poppins",
@@ -3554,6 +3674,11 @@
           }
         }
       },
+      "card_borders": "image",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "none",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -3663,6 +3788,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "open-sans",
@@ -3729,6 +3855,11 @@
           }
         }
       },
+      "card_borders": "image",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "large",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -3838,6 +3969,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "open-sans",
@@ -3904,6 +4036,11 @@
           }
         }
       },
+      "card_borders": "full",
+      "card_color_scheme": "set-1",
+      "card_image_background": false,
+      "card_image_fit": "cover",
+      "card_rounded_corners": "small",
       "corner_radius": "fully_round",
       "font_weight_h1": "800",
       "font_weight_h2": "800",
@@ -4014,6 +4151,7 @@
           "disabled": null
         }
       },
+      "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -178,6 +178,7 @@
       "social_spacing": "md",
       "tagline_font": "open-sans",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "adventure": {
@@ -358,6 +359,7 @@
       "social_spacing": "md",
       "tagline_font": "roboto",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "boost": {
@@ -539,6 +541,7 @@
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "bounce": {
@@ -720,6 +723,7 @@
       "social_spacing": "md",
       "tagline_font": "open-sans",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "capture": {
@@ -901,6 +905,7 @@
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "cruise": {
@@ -1082,6 +1087,7 @@
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "daredevil": {
@@ -1262,6 +1268,7 @@
       "social_spacing": "md",
       "tagline_font": "open-sans",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "elegant": {
@@ -1443,6 +1450,7 @@
       "social_spacing": "md",
       "tagline_font": "dm-sans",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "explore": {
@@ -1623,6 +1631,7 @@
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "flow": {
@@ -1803,6 +1812,7 @@
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "freedom": {
@@ -1984,6 +1994,7 @@
       "social_spacing": "md",
       "tagline_font": "roboto",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "giro": {
@@ -2165,6 +2176,7 @@
       "social_spacing": "md",
       "tagline_font": "open-sans",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "joy": {
@@ -2346,6 +2358,7 @@
       "social_spacing": "md",
       "tagline_font": "open-sans",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "memories": {
@@ -2527,6 +2540,7 @@
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "nite": {
@@ -2708,6 +2722,7 @@
       "social_spacing": "md",
       "tagline_font": "poppins",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "peak": {
@@ -2889,6 +2904,7 @@
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "play": {
@@ -3070,6 +3086,7 @@
       "social_spacing": "md",
       "tagline_font": "baloo-2",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "pure": {
@@ -3250,6 +3267,7 @@
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "ride": {
@@ -3431,6 +3449,7 @@
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "rush": {
@@ -3612,6 +3631,7 @@
       "social_spacing": "md",
       "tagline_font": "poppins",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "sunset": {
@@ -3793,6 +3813,7 @@
       "social_spacing": "md",
       "tagline_font": "open-sans",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "tough": {
@@ -3974,6 +3995,7 @@
       "social_spacing": "md",
       "tagline_font": "open-sans",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "vice": {
@@ -4156,6 +4178,7 @@
       "social_spacing": "md",
       "tagline_font": "darker-grotesque",
       "tagline_size": 20,
+      "use_card_color_scheme": false,
       "use_focal_images": true
     }
   }

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -58,6 +58,109 @@
     ]
   },
   {
+    "name": "Product card",
+    "settings": [
+      {
+        "type": "color_scheme",
+        "id": "card_color_scheme",
+        "label": "Color scheme",
+        "default": "set-1"
+      },
+      {
+        "type": "paragraph",
+        "content": "Works if 'Around whole product' border style is chosen"
+      },
+      {
+        "type": "header",
+        "content": "Image settings"
+      },
+      {
+        "type": "select",
+        "id": "card_image_fit",
+        "label": "Image fit",
+        "options": [
+          {
+            "value": "cover",
+            "label": "Cover"
+          },
+          {
+            "value": "contain",
+            "label": "Contain"
+          }
+        ],
+        "default": "contain"
+      },
+      {
+        "type": "checkbox",
+        "id": "use_focal_images",
+        "label": "Use focal image",
+        "default": true,
+        "info": "Display point focused image instead of full sized. Works with 'Cover' image fit option together"
+      },
+      {
+        "type": "checkbox",
+        "id": "card_image_background",
+        "label": "Use transparent background",
+        "default": false,
+        "info": "Display gaps above and below image. Works with 'Contain' image fit option together"
+      },
+      {
+        "type": "select",
+        "id": "card_borders",
+        "label": "Border style",
+        "options": [
+          {
+            "value": "none",
+            "label": "None"
+          },
+          {
+            "value": "image",
+            "label": "Around image"
+          },
+          {
+            "value": "full",
+            "label": "Around whole product"
+          }
+        ],
+        "default": "image"
+      },
+      {
+        "type": "select",
+        "id": "card_rounded_corners",
+        "label": "Rounded corners",
+        "options": [
+          {
+            "value": "none",
+            "label": "None"
+          },
+          {
+            "value": "small",
+            "label": "Small"
+          },
+          {
+            "value": "medium",
+            "label": "Medium"
+          },
+          {
+            "value": "large",
+            "label": "Large"
+          }
+        ],
+        "default": "none"
+      },
+      {
+        "type": "header",
+        "content": "Text settings"
+      },
+      {
+        "type": "checkbox",
+        "id": "show_card_excerpt",
+        "default": false,
+        "label": "Show description excerpt"
+      }
+    ]
+  },
+  {
     "name": "Typography",
     "settings": [
       {
@@ -310,13 +413,6 @@
   {
     "name": "Images",
     "settings": [
-      {
-        "type": "checkbox",
-        "id": "use_focal_images",
-        "label": "Use focal images",
-        "default": true,
-        "info": "Display point focused images for products instead of full sized"
-      },
       {
         "type": "image_picker",
         "id": "image_placeholder",

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -71,6 +71,13 @@
         "content": "Works if 'Around whole product' border style is chosen"
       },
       {
+        "type": "checkbox",
+        "id": "use_card_color_scheme",
+        "label": "Use color scheme",
+        "default": false,
+        "info": "Use these colors instead of section ones"
+      },
+      {
         "type": "header",
         "content": "Image settings"
       },
@@ -88,7 +95,7 @@
             "label": "Contain"
           }
         ],
-        "default": "contain"
+        "default": "cover"
       },
       {
         "type": "checkbox",
@@ -102,7 +109,7 @@
         "id": "card_image_background",
         "label": "Use transparent background",
         "default": false,
-        "info": "Display gaps above and below image. Works with 'Contain' image fit option together"
+        "info": "Display gaps above and below image. Works together with 'Contain' image fit option and if using the color scheme"
       },
       {
         "type": "select",

--- a/sections/collection-page.liquid
+++ b/sections/collection-page.liquid
@@ -1,14 +1,9 @@
 {{ "collection-page.css" | asset_url | stylesheet_tag }}
 {{ "product-card.css" | asset_url | stylesheet_tag }}
 
-{%- assign borders               = section.settings.borders -%}
-{%- assign border                = false -%}
 {%- assign color_scheme          = section.settings.color_scheme -%}
 {%- assign full_width            = section.settings.full_width -%}
 {%- assign grid                  = section.settings.grid -%}
-{%- assign image_fit             = section.settings.image_fit -%}
-{%- assign image_placeholder     = settings.image_placeholder -%}
-{%- assign is_focal              = false -%}
 {%- assign limit                 = section.settings.limit -%}
 {%- assign menu                  = false -%}
 {%- assign message               = section.settings.message -%}
@@ -17,13 +12,7 @@
 {%- assign padding_bottom        = section.settings.padding_bottom -%}
 {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
 {%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
-{%- assign rounded_corners       = section.settings.rounded_corners -%}
-{%- assign show_excerpt          = section.settings.show_excerpt -%}
 {%- assign sticky_sidebar        = section.settings.sticky_sidebar -%}
-
-{%- if settings.use_focal_images and image_fit == 'cover' -%}
-  {%- assign is_focal = true -%}
-{%- endif -%}
 
 {%- for block in section.blocks -%}
   {%- assign menu = block.settings.menu -%}
@@ -33,13 +22,6 @@
     {%- break -%}
   {%- endif -%}
 {%- endfor -%}
-
-{%- case borders -%}
-  {%- when 'image' -%}
-    {%- assign border = "image" -%}
-  {%- when 'full' -%}
-    {%- assign border = "full" -%}
-{%- endcase -%}
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
@@ -79,13 +61,6 @@
       --padding-bottom-mobile: 60px;
   {%- endcase -%}
 
-  {%- case image_fit -%}
-    {%- when 'cover' -%}
-      --object-fit: cover;
-    {%- when 'contain' -%}
-      --object-fit: contain;
-  {%- endcase -%}
-
   {%- case grid -%}
     {%- when 'two' -%}
       --grid-element: 2;
@@ -96,17 +71,6 @@
     {%- when 'four' -%}
       --grid-element: 4;
       --item-min-width: 160px;
-  {%- endcase -%}
-
-  {%- case rounded_corners -%}
-    {%- when 'none' -%}
-      --border-radius-rounded-blocks: 0px;
-    {%- when 'small' -%}
-      --border-radius-rounded-blocks: 8px;
-    {%- when 'medium' -%}
-      --border-radius-rounded-blocks: 16px;
-    {%- when 'large' -%}
-      --border-radius-rounded-blocks: 32px;
   {%- endcase -%}
 {%- endcapture -%}
 {% comment %} CSS variables end {% endcomment %}
@@ -134,10 +98,7 @@
               {%- for product in products -%}
                 {%- render 'product-card',
                     product: product,
-                    placeholder: image_placeholder,
-                    border: border,
-                    focal: is_focal,
-                    show_excerpt: show_excerpt
+                    settings: settings
                 -%}
               {%- endfor -%}
             </div>
@@ -183,72 +144,6 @@
         "id": "full_width",
         "label": "Stretch products to screen edges",
         "default": false
-      },
-      {
-        "type": "select",
-        "id": "rounded_corners",
-        "label": "Rounded corners",
-        "options": [
-          {
-            "value": "none",
-            "label": "None"
-          },
-          {
-            "value": "small",
-            "label": "Small"
-          },
-          {
-            "value": "medium",
-            "label": "Medium"
-          },
-          {
-            "value": "large",
-            "label": "Large"
-          }
-        ],
-        "default": "none"
-      },
-      {
-        "type": "checkbox",
-        "id": "show_excerpt",
-        "default": true,
-        "label": "Show product description excerpt"
-      },
-      {
-        "type": "select",
-        "id": "image_fit",
-        "label": "Image fit",
-        "options": [
-          {
-            "value": "cover",
-            "label": "Cover"
-          },
-          {
-            "value": "contain",
-            "label": "Contain"
-          }
-        ],
-        "default": "cover"
-      },
-      {
-        "type": "select",
-        "id": "borders",
-        "label": "Border style",
-        "options": [
-          {
-            "value": "none",
-            "label": "None"
-          },
-          {
-            "value": "image",
-            "label": "Around image"
-          },
-          {
-            "value": "full",
-            "label": "Around whole product"
-          }
-        ],
-        "default": "image"
       },
       {
         "type": "number",

--- a/sections/products.liquid
+++ b/sections/products.liquid
@@ -26,31 +26,21 @@
   {{ "products.css" | asset_url | stylesheet_tag }}
   {{ "product-card.css" | asset_url | stylesheet_tag }}
 
-  {%- assign borders               = section.settings.borders -%}
   {%- assign button_outline_label  = section.settings.button_outline_label -%}
   {%- assign button_outline_url    = section.settings.button_outline_url -%}
   {%- assign color_scheme          = section.settings.color_scheme -%}
   {%- assign image                 = section.settings.image -%}
-  {%- assign image_fit             = section.settings.image_fit -%}
-  {%- assign image_placeholder     = settings.image_placeholder -%}
-  {%- assign is_focal              = false -%}
   {%- assign limit                 = 8 -%}
   {%- assign padding_top           = section.settings.padding_top -%}
   {%- assign padding_bottom        = section.settings.padding_bottom -%}
   {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
   {%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
-  {%- assign rounded_corners       = section.settings.rounded_corners -%}
-  {%- assign show_excerpt          = section.settings.show_excerpt -%}
   {%- assign show_navigation       = section.settings.show_navigation -%}
   {%- assign show_pagination       = section.settings.show_pagination -%}
   {%- assign tag                   = section.settings.tag -%}
   {%- assign tag_image             = section.settings.tag_image -%}
   {%- assign timer                 = section.settings.timer -%}
   {%- assign title                 = section.settings.title -%}
-
-  {%- if settings.use_focal_images and image_fit == 'cover' -%}
-    {%- assign is_focal = true -%}
-  {%- endif -%}
 
   {%- assign carousel = false -%}
 
@@ -63,15 +53,6 @@
       {%- assign limit = nil -%}
     {% endunless %}
   {%- endif -%}
-
-  {%- assign border = false -%}
-
-  {%- case borders -%}
-    {%- when 'image' -%}
-      {%- assign border = "image" -%}
-    {%- when 'full' -%}
-      {%- assign border = "full" -%}
-  {%- endcase -%}
 
   {% comment %} CSS variables start {% endcomment %}
   {%- capture variables -%}
@@ -109,24 +90,6 @@
         --padding-bottom-mobile: 40px;
       {%- when 'large' -%}
         --padding-bottom-mobile: 60px;
-    {%- endcase -%}
-
-    {%- case image_fit -%}
-      {%- when 'cover' -%}
-        --object-fit: cover;
-      {%- when 'contain' -%}
-        --object-fit: contain;
-    {%- endcase -%}
-
-    {%- case rounded_corners -%}
-      {%- when 'none' -%}
-        --border-radius-rounded-blocks: 0px;
-      {%- when 'small' -%}
-        --border-radius-rounded-blocks: 8px;
-      {%- when 'medium' -%}
-        --border-radius-rounded-blocks: 16px;
-      {%- when 'large' -%}
-        --border-radius-rounded-blocks: 32px;
     {%- endcase -%}
   {%- endcapture -%}
   {% comment %} CSS variables end {% endcomment %}
@@ -180,10 +143,7 @@
               {%- endif -%}
                     {%- render 'product-card',
                         product: product,
-                        placeholder: image_placeholder,
-                        border: border,
-                        focal: is_focal,
-                        show_excerpt: show_excerpt
+                        settings: settings
                     -%}
               {%- if carousel -%}
                   </div>
@@ -283,72 +243,6 @@
         "type": "image_picker",
         "id": "image",
         "label": "Background image"
-      },
-      {
-        "type": "select",
-        "id": "image_fit",
-        "label": "Image fit",
-        "options": [
-          {
-            "value": "cover",
-            "label": "Cover"
-          },
-          {
-            "value": "contain",
-            "label": "Contain"
-          }
-        ],
-        "default": "cover"
-      },
-      {
-        "type": "select",
-        "id": "borders",
-        "label": "Border style",
-        "options": [
-          {
-            "value": "none",
-            "label": "None"
-          },
-          {
-            "value": "image",
-            "label": "Around image"
-          },
-          {
-            "value": "full",
-            "label": "Around whole product"
-          }
-        ],
-        "default": "image"
-      },
-      {
-        "type": "select",
-        "id": "rounded_corners",
-        "label": "Rounded corners",
-        "options": [
-          {
-            "value": "none",
-            "label": "None"
-          },
-          {
-            "value": "small",
-            "label": "Small"
-          },
-          {
-            "value": "medium",
-            "label": "Medium"
-          },
-          {
-            "value": "large",
-            "label": "Large"
-          }
-        ],
-        "default": "none"
-      },
-      {
-        "type": "checkbox",
-        "id": "show_excerpt",
-        "default": true,
-        "label": "Show product description excerpt"
       },
       {
         "type": "header",

--- a/sections/search.liquid
+++ b/sections/search.liquid
@@ -1,15 +1,10 @@
 {{ "search.css" | asset_url | stylesheet_tag }}
 {{ "product-card.css" | asset_url | stylesheet_tag }}
 
-{%- assign borders               = section.settings.borders -%}
-{%- assign border                = false -%}
 {%- assign collection            = section.settings.collection -%}
 {%- assign color_scheme          = section.settings.color_scheme -%}
 {%- assign full_width            = section.settings.full_width -%}
 {%- assign grid                  = section.settings.grid -%}
-{%- assign image_fit             = section.settings.image_fit -%}
-{%- assign image_placeholder     = settings.image_placeholder -%}
-{%- assign is_focal              = false -%}
 {%- assign limit                 = 8 -%}
 {%- assign menu                  = false -%}
 {%- assign message               = section.settings.message -%}
@@ -19,16 +14,10 @@
 {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
 {%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
 {%- assign results_limit         = section.settings.results_limit -%}
-{%- assign rounded_corners       = section.settings.rounded_corners -%}
-{%- assign show_excerpt          = section.settings.show_excerpt -%}
 {%- assign show_navigation       = section.settings.show_navigation -%}
 {%- assign show_pagination       = section.settings.show_pagination -%}
 {%- assign timer                 = section.settings.timer -%}
 {%- assign sticky_sidebar        = section.settings.sticky_sidebar -%}
-
-{%- if settings.use_focal_images and image_fit == 'cover' -%}
-  {%- assign is_focal = true -%}
-{%- endif -%}
 
 {%- for block in section.blocks -%}
   {%- assign menu = block.settings.menu -%}
@@ -48,13 +37,6 @@
     {%- assign limit = nil -%}
   {% endunless %}
 {%- endif -%}
-
-{%- case borders -%}
-  {%- when 'image' -%}
-    {%- assign border = "image" -%}
-  {%- when 'full' -%}
-    {%- assign border = "full" -%}
-{%- endcase -%}
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
@@ -94,13 +76,6 @@
       --padding-bottom-mobile: 60px;
   {%- endcase -%}
 
-  {%- case image_fit -%}
-    {%- when 'cover' -%}
-      --object-fit: cover;
-    {%- when 'contain' -%}
-      --object-fit: contain;
-  {%- endcase -%}
-
   {%- case grid -%}
     {%- when 'two' -%}
       --grid-element: 2;
@@ -108,17 +83,6 @@
       --grid-element: 3;
     {%- when 'four' -%}
       --grid-element: 4;
-  {%- endcase -%}
-
-  {%- case rounded_corners -%}
-    {%- when 'none' -%}
-      --border-radius-rounded-blocks: 0px;
-    {%- when 'small' -%}
-      --border-radius-rounded-blocks: 8px;
-    {%- when 'medium' -%}
-      --border-radius-rounded-blocks: 16px;
-    {%- when 'large' -%}
-      --border-radius-rounded-blocks: 32px;
   {%- endcase -%}
 {%- endcapture -%}
 {% comment %} CSS variables end {% endcomment %}
@@ -143,10 +107,7 @@
                   {%- for result in results -%}
                     {%- render 'product-card',
                         product: result,
-                        placeholder: image_placeholder,
-                        border: border,
-                        focal: is_focal,
-                        show_excerpt: show_excerpt
+                        settings: settings
                     -%}
                   {%- endfor -%}
                 </div>
@@ -188,10 +149,7 @@
                       <div class="carousel__inner">
                         {%- render 'product-card',
                             product: product,
-                            placeholder: image_placeholder,
-                            border: border,
-                            focal: is_focal,
-                            show_excerpt: show_excerpt
+                            settings: settings
                         -%}
                       </div>
                     </div>
@@ -257,72 +215,6 @@
         "id": "full_width",
         "label": "Stretch products to screen edges",
         "default": false
-      },
-      {
-        "type": "select",
-        "id": "rounded_corners",
-        "label": "Rounded corners",
-        "options": [
-          {
-            "value": "none",
-            "label": "None"
-          },
-          {
-            "value": "small",
-            "label": "Small"
-          },
-          {
-            "value": "medium",
-            "label": "Medium"
-          },
-          {
-            "value": "large",
-            "label": "Large"
-          }
-        ],
-        "default": "none"
-      },
-      {
-        "type": "checkbox",
-        "id": "show_excerpt",
-        "default": true,
-        "label": "Show product description excerpt"
-      },
-      {
-        "type": "select",
-        "id": "image_fit",
-        "label": "Image fit",
-        "options": [
-          {
-            "value": "cover",
-            "label": "Cover"
-          },
-          {
-            "value": "contain",
-            "label": "Contain"
-          }
-        ],
-        "default": "cover"
-      },
-      {
-        "type": "select",
-        "id": "borders",
-        "label": "Border style",
-        "options": [
-          {
-            "value": "none",
-            "label": "None"
-          },
-          {
-            "value": "image",
-            "label": "Around image"
-          },
-          {
-            "value": "full",
-            "label": "Around whole product"
-          }
-        ],
-        "default": "image"
       },
       {
         "type": "paragraph",

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -30,6 +30,7 @@
 {%- assign rounded_corners = settings.card_rounded_corners -%}
 {%- assign show_excerpt    = settings.show_card_excerpt -%}
 {%- assign url             = "" -%}
+{%- assign use_colors      = settings.use_card_color_scheme -%}
 {%- assign use_focal       = settings.use_focal_images -%}
 
 {%- if product != blank -%}
@@ -90,7 +91,7 @@
 {%- endcapture -%}
 {% comment %} CSS variables end {% endcomment %}
 
-<div class="product-card product-card--{{- border -}}-border{% if border == "full" %} color-{{- color_scheme.id -}}{%- endif -%}"{% if id != blank %} id="{{- id -}}"{% endif %} style="{{- card_variables | escape -}}">
+<div class="product-card product-card--{{- border -}}-border{% if border == "full" and use_colors %} color-{{- color_scheme.id -}}{%- endif -%}"{% if id != blank %} id="{{- id -}}"{% endif %} style="{{- card_variables | escape -}}">
   <div class="product-card__vision{% if image_fit == 'contain' %}{% unless image_bg %} product-card__vision--white{% endunless %}{% endif %}{% unless image.url != blank %} no-image{%- endunless -%}">
     {%- if image.url != blank -%}
       {%- render 'image',

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -1,35 +1,36 @@
 {% comment %}
 
-  This snippet is used for rendering the product
+  This snippet is used for rendering the product card
 
   product - { product } *required,
-  placeholder - image optional,
-  border - string optional,
-  focal - boolean optional,
   img_size - string optional,
-  show_excerpt - boolean *required
+  settings - { object } *required
 
   Usage:
 
   {%- render 'product-card',
-      product: your_id,
-      placeholder: your_id,
-      border: your_id,
-      focal: your_id,
-      img_size: your_string,
-      show_excerpt: true
+      settings: settings,
+      img_size: your_string
   -%}
 
 {% endcomment %}
 
-{%- assign id      = "" -%}
-{%- assign url     = "" -%}
-{%- assign image   = "" -%}
-{%- assign name    = "" -%}
-{%- assign excerpt = "" -%}
-{%- assign points  = nil -%}
-{%- assign price   = "" -%}
-{%- assign period  = "" -%}
+{%- assign border          = settings.card_borders -%}
+{%- assign color_scheme    = settings.card_color_scheme -%}
+{%- assign excerpt         = "" -%}
+{%- assign id              = "" -%}
+{%- assign image           = "" -%}
+{%- assign image_bg        = settings.card_image_background -%}
+{%- assign image_fit       = settings.card_image_fit -%}
+{%- assign name            = "" -%}
+{%- assign period          = "" -%}
+{%- assign placeholder     = settings.image_placeholder -%}
+{%- assign points          = nil -%}
+{%- assign price           = "" -%}
+{%- assign rounded_corners = settings.card_rounded_corners -%}
+{%- assign show_excerpt    = settings.show_card_excerpt -%}
+{%- assign url             = "" -%}
+{%- assign use_focal       = settings.use_focal_images -%}
 
 {%- if product != blank -%}
   {%- if product.images != blank -%}
@@ -44,9 +45,9 @@
     {%- assign img_size = 'flexible' -%}
   {%- endif -%}
 
-  {% if focal %}
+  {%- if use_focal and image_fit == 'cover' -%}
     {%- assign points = image.coordinates -%}
-  {% endif %}
+  {%- endif -%}
 
   {%- assign id      = product.id -%}
   {%- assign url     = product.url -%}
@@ -67,8 +68,30 @@
   {%- assign period  = "1 day" -%}
 {%- endif -%}
 
-<div class="product-card product-card--{{- border -}}-border" {% if id != blank %}id="{{- id -}}"{%- endif -%}>
-  <div class="product-card__vision{% unless image.url != blank %} no-image{%- endunless -%}">
+{% comment %} CSS variables start {% endcomment %}
+{%- capture card_variables -%}
+  {%- case image_fit -%}
+    {%- when 'cover' -%}
+      --object-fit: cover;
+    {%- when 'contain' -%}
+      --object-fit: contain;
+  {%- endcase -%}
+
+  {%- case rounded_corners -%}
+    {%- when 'none' -%}
+      --border-radius-rounded-blocks: 0px;
+    {%- when 'small' -%}
+      --border-radius-rounded-blocks: 8px;
+    {%- when 'medium' -%}
+      --border-radius-rounded-blocks: 16px;
+    {%- when 'large' -%}
+      --border-radius-rounded-blocks: 32px;
+  {%- endcase -%}
+{%- endcapture -%}
+{% comment %} CSS variables end {% endcomment %}
+
+<div class="product-card product-card--{{- border -}}-border{% if border == "full" %} color-{{- color_scheme.id -}}{%- endif -%}"{% if id != blank %} id="{{- id -}}"{% endif %} style="{{- card_variables | escape -}}">
+  <div class="product-card__vision{% if image_fit == 'contain' %}{% unless image_bg %} product-card__vision--white{% endunless %}{% endif %}{% unless image.url != blank %} no-image{%- endunless -%}">
     {%- if image.url != blank -%}
       {%- render 'image',
         image: image,

--- a/snippets/section-transition.liquid
+++ b/snippets/section-transition.liquid
@@ -10,13 +10,6 @@
   show_top: boolean *required,
   show_bottom: boolean *required
 
-  product - { product } *required,
-  placeholder - image optional,
-  border - string optional,
-  focal - boolean optional,
-  img_size - string optional,
-  show_excerpt - boolean *required
-
   Usage:
 
   {%- render 'section-transition',

--- a/templates/adrenaline/collection.json
+++ b/templates/adrenaline/collection.json
@@ -41,11 +41,9 @@
         "item_364579"
       ],
       "settings": {
-        "borders": "image",
         "color_scheme": "set-1",
         "full_width": false,
         "grid": "three",
-        "image_fit": "cover",
         "limit": 18,
         "message": "SORRY, THERE ARE NO PRODUCTS IN THIS COLLECTION YET",
         "mobile_toggler": "MENU",
@@ -53,8 +51,6 @@
         "padding_bottom_mobile": "small",
         "padding_top": "medium",
         "padding_top_mobile": "small",
-        "rounded_corners": "large",
-        "show_excerpt": false,
         "sticky_sidebar": true
       },
       "disabled": null

--- a/templates/adrenaline/index.json
+++ b/templates/adrenaline/index.json
@@ -163,18 +163,14 @@
         "product_109849"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "SEE ALL PRODUCTS",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "large",
         "padding_top": "medium",
         "padding_top_mobile": "large",
-        "rounded_corners": "large",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/adrenaline/product.json
+++ b/templates/adrenaline/product.json
@@ -62,7 +62,6 @@
         "product_129802"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "SEE ALL PRODUCTS",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
@@ -71,8 +70,6 @@
         "padding_bottom_mobile": "large",
         "padding_top": "large",
         "padding_top_mobile": "large",
-        "rounded_corners": "large",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "",

--- a/templates/adrenaline/search.json
+++ b/templates/adrenaline/search.json
@@ -41,12 +41,10 @@
         "item_360279"
       ],
       "settings": {
-        "borders": "image",
         "collection": "all-products",
         "color_scheme": "set-1",
         "full_width": false,
         "grid": "three",
-        "image_fit": "cover",
         "limit": 18,
         "message": "",
         "mobile_toggler": "MENU",
@@ -54,8 +52,6 @@
         "padding_bottom_mobile": "small",
         "padding_top": "medium",
         "padding_top_mobile": "small",
-        "rounded_corners": "large",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "sticky_sidebar": true,

--- a/templates/adventure/collection.json
+++ b/templates/adventure/collection.json
@@ -41,11 +41,9 @@
         "item"
       ],
       "settings": {
-        "borders": "image",
         "color_scheme": "set-5",
         "full_width": false,
         "grid": "three",
-        "image_fit": "cover",
         "limit": 18,
         "message": "Sorry, there are no products in this collection yet",
         "mobile_toggler": "MENU",
@@ -53,8 +51,6 @@
         "padding_bottom_mobile": "small",
         "padding_top": "medium",
         "padding_top_mobile": "small",
-        "rounded_corners": "small",
-        "show_excerpt": false,
         "sticky_sidebar": true
       },
       "disabled": null

--- a/templates/adventure/index.json
+++ b/templates/adventure/index.json
@@ -170,18 +170,14 @@
         "product_789649"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "booqable://assets/image-background-beige-dots.jpg",
-        "image_fit": "cover",
         "padding_bottom": "large",
         "padding_bottom_mobile": "medium",
         "padding_top": "large",
         "padding_top_mobile": "medium",
-        "rounded_corners": "small",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/adventure/product.json
+++ b/templates/adventure/product.json
@@ -62,7 +62,6 @@
         "product_175158"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-5",
@@ -71,8 +70,6 @@
         "padding_bottom_mobile": "large",
         "padding_top": "medium",
         "padding_top_mobile": "medium",
-        "rounded_corners": "small",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "",

--- a/templates/adventure/search.json
+++ b/templates/adventure/search.json
@@ -41,12 +41,10 @@
         "item_674376"
       ],
       "settings": {
-        "borders": "image",
         "collection": "all-products",
         "color_scheme": "set-5",
         "full_width": false,
         "grid": "three",
-        "image_fit": "cover",
         "limit": 18,
         "message": "",
         "mobile_toggler": "MENU",
@@ -54,8 +52,6 @@
         "padding_bottom_mobile": "small",
         "padding_top": "medium",
         "padding_top_mobile": "small",
-        "rounded_corners": "small",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "sticky_sidebar": true,

--- a/templates/boost/index.json
+++ b/templates/boost/index.json
@@ -175,18 +175,14 @@
         "product_107549"
       ],
       "settings": {
-        "borders": "full",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",
         "padding_top_mobile": "medium",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/bounce/index.json
+++ b/templates/bounce/index.json
@@ -167,18 +167,14 @@
         "product_109849"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "large",
         "padding_top": "medium",
         "padding_top_mobile": "large",
-        "rounded_corners": "large",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/capture/index.json
+++ b/templates/capture/index.json
@@ -144,18 +144,14 @@
         "product_123751"
       ],
       "settings": {
-        "borders": "full",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",
         "padding_top_mobile": "medium",
-        "rounded_corners": "small",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/collection.json
+++ b/templates/collection.json
@@ -41,11 +41,9 @@
         "item"
       ],
       "settings": {
-        "borders": "full",
         "color_scheme": "set-1",
         "full_width": false,
         "grid": "three",
-        "image_fit": "cover",
         "limit": 18,
         "message": "Sorry, there are no products in this collection yet",
         "mobile_toggler": "MENU",
@@ -53,8 +51,6 @@
         "padding_bottom_mobile": "small",
         "padding_top": "medium",
         "padding_top_mobile": "small",
-        "rounded_corners": "small",
-        "show_excerpt": false,
         "sticky_sidebar": true
       },
       "disabled": null

--- a/templates/cruise/index.json
+++ b/templates/cruise/index.json
@@ -175,18 +175,14 @@
         "product_913449"
       ],
       "settings": {
-        "borders": "full",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-2",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",
         "padding_top_mobile": "medium",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/daredevil/collection.json
+++ b/templates/daredevil/collection.json
@@ -41,11 +41,9 @@
         "item"
       ],
       "settings": {
-        "borders": "image",
         "color_scheme": "set-1",
         "full_width": false,
         "grid": "three",
-        "image_fit": "cover",
         "limit": 18,
         "message": "Sorry, there are no products in this collection yet",
         "mobile_toggler": "Menu",
@@ -53,8 +51,6 @@
         "padding_bottom_mobile": "small",
         "padding_top": "small",
         "padding_top_mobile": "small",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "sticky_sidebar": true
       },
       "disabled": null

--- a/templates/daredevil/index.json
+++ b/templates/daredevil/index.json
@@ -162,18 +162,14 @@
         "product_123449"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "none",
         "padding_bottom_mobile": "none",
         "padding_top": "none",
         "padding_top_mobile": "none",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "",

--- a/templates/daredevil/product.json
+++ b/templates/daredevil/product.json
@@ -86,7 +86,6 @@
         "product_123452"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
@@ -95,8 +94,6 @@
         "padding_bottom_mobile": "large",
         "padding_top": "none",
         "padding_top_mobile": "none",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "",

--- a/templates/daredevil/search.json
+++ b/templates/daredevil/search.json
@@ -41,12 +41,10 @@
         "item_674326"
       ],
       "settings": {
-        "borders": "image",
         "collection": "all-products",
         "color_scheme": "set-1",
         "full_width": false,
         "grid": "three",
-        "image_fit": "cover",
         "limit": 18,
         "message": "",
         "mobile_toggler": "Menu",
@@ -54,8 +52,6 @@
         "padding_bottom_mobile": "small",
         "padding_top": "small",
         "padding_top_mobile": "small",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "sticky_sidebar": true,

--- a/templates/elegant/index.json
+++ b/templates/elegant/index.json
@@ -123,18 +123,14 @@
         "product_123751"
       ],
       "settings": {
-        "borders": "full",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",
         "padding_top_mobile": "medium",
-        "rounded_corners": "small",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/explore/collection.json
+++ b/templates/explore/collection.json
@@ -41,11 +41,9 @@
         "item_298765"
       ],
       "settings": {
-        "borders": "image",
         "color_scheme": "set-1",
         "full_width": false,
         "grid": "three",
-        "image_fit": "cover",
         "limit": 18,
         "message": "Sorry, there are no products in this collection yet",
         "mobile_toggler": "Menu",
@@ -53,8 +51,6 @@
         "padding_bottom_mobile": "small",
         "padding_top": "medium",
         "padding_top_mobile": "small",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "sticky_sidebar": true
       },
       "disabled": null

--- a/templates/explore/index.json
+++ b/templates/explore/index.json
@@ -181,18 +181,14 @@
         "product_223449"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "small",
         "padding_bottom_mobile": "small",
         "padding_top": "medium",
         "padding_top_mobile": "large",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "This week",

--- a/templates/explore/product.json
+++ b/templates/explore/product.json
@@ -62,7 +62,6 @@
         "product_323452"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
@@ -71,8 +70,6 @@
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",
         "padding_top_mobile": "medium",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "",

--- a/templates/explore/search.json
+++ b/templates/explore/search.json
@@ -41,12 +41,10 @@
         "item_874326"
       ],
       "settings": {
-        "borders": "image",
         "collection": "all-products",
         "color_scheme": "set-1",
         "full_width": false,
         "grid": "three",
-        "image_fit": "cover",
         "limit": 18,
         "message": "",
         "mobile_toggler": "Menu",
@@ -54,8 +52,6 @@
         "padding_bottom_mobile": "small",
         "padding_top": "medium",
         "padding_top_mobile": "small",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "sticky_sidebar": true,

--- a/templates/flow/collection.json
+++ b/templates/flow/collection.json
@@ -41,11 +41,9 @@
         "item_985214"
       ],
       "settings": {
-        "borders": "full",
         "color_scheme": "set-1",
         "full_width": false,
         "grid": "three",
-        "image_fit": "cover",
         "limit": 18,
         "message": "Sorry, there are no products in this collection yet",
         "mobile_toggler": "MENU",
@@ -53,8 +51,6 @@
         "padding_bottom_mobile": "small",
         "padding_top": "medium",
         "padding_top_mobile": "small",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "sticky_sidebar": true
       },
       "disabled": null

--- a/templates/flow/index.json
+++ b/templates/flow/index.json
@@ -169,18 +169,14 @@
         "product_654449"
       ],
       "settings": {
-        "borders": "full",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",
         "padding_top_mobile": "medium",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/flow/product.json
+++ b/templates/flow/product.json
@@ -62,7 +62,6 @@
         "product_557898"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
@@ -71,8 +70,6 @@
         "padding_bottom_mobile": "large",
         "padding_top": "medium",
         "padding_top_mobile": "medium",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "",

--- a/templates/flow/search.json
+++ b/templates/flow/search.json
@@ -41,12 +41,10 @@
         "item_674746"
       ],
       "settings": {
-        "borders": "full",
         "collection": "all-products",
         "color_scheme": "set-1",
         "full_width": false,
         "grid": "three",
-        "image_fit": "cover",
         "limit": 18,
         "message": "",
         "mobile_toggler": "MENU",
@@ -54,8 +52,6 @@
         "padding_bottom_mobile": "small",
         "padding_top": "medium",
         "padding_top_mobile": "small",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "sticky_sidebar": true,

--- a/templates/freedom/index.json
+++ b/templates/freedom/index.json
@@ -175,18 +175,14 @@
         "product_123751"
       ],
       "settings": {
-        "borders": "full",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",
         "padding_top_mobile": "medium",
-        "rounded_corners": "small",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/giro/index.json
+++ b/templates/giro/index.json
@@ -136,18 +136,14 @@
         "product_109849"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "large",
         "padding_top": "medium",
         "padding_top_mobile": "large",
-        "rounded_corners": "large",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/joy/index.json
+++ b/templates/joy/index.json
@@ -168,18 +168,14 @@
         "product_654449"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "none",
         "padding_bottom_mobile": "large",
         "padding_top": "none",
         "padding_top_mobile": "large",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "",

--- a/templates/memories/index.json
+++ b/templates/memories/index.json
@@ -175,18 +175,14 @@
         "product_123751"
       ],
       "settings": {
-        "borders": "full",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",
         "padding_top_mobile": "medium",
-        "rounded_corners": "small",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/nite/index.json
+++ b/templates/nite/index.json
@@ -136,18 +136,14 @@
         "product_109849"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "large",
         "padding_top": "medium",
         "padding_top_mobile": "large",
-        "rounded_corners": "large",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/peak/index.json
+++ b/templates/peak/index.json
@@ -175,18 +175,14 @@
         "product_223449"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "small",
         "padding_bottom_mobile": "small",
         "padding_top": "medium",
         "padding_top_mobile": "large",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "This week",
@@ -343,8 +339,8 @@
       },
       "block_order": [
         "article",
-      "article_456731",
-      "article_456732"
+        "article_456731",
+        "article_456732"
       ],
       "settings": {
         "button_outline_label": "See all",

--- a/templates/play/index.json
+++ b/templates/play/index.json
@@ -191,18 +191,14 @@
         "product_109849"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-2",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "large",
         "padding_top": "small",
         "padding_top_mobile": "large",
-        "rounded_corners": "large",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "",

--- a/templates/product.json
+++ b/templates/product.json
@@ -62,7 +62,6 @@
         "product_123034"
       ],
       "settings": {
-        "borders": "full",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
@@ -71,8 +70,6 @@
         "padding_bottom_mobile": "large",
         "padding_top": "medium",
         "padding_top_mobile": "medium",
-        "rounded_corners": "small",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "",

--- a/templates/pure/index.json
+++ b/templates/pure/index.json
@@ -138,18 +138,14 @@
         "product_123751"
       ],
       "settings": {
-        "borders": "full",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",
         "padding_top_mobile": "medium",
-        "rounded_corners": "small",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/ride/index.json
+++ b/templates/ride/index.json
@@ -92,18 +92,14 @@
         "product_123751"
       ],
       "settings": {
-        "borders": "full",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",
         "padding_top_mobile": "medium",
-        "rounded_corners": "small",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/rush/index.json
+++ b/templates/rush/index.json
@@ -191,18 +191,14 @@
         "product_109849"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "SEE ALL PRODUCTS",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "large",
         "padding_top": "medium",
         "padding_top_mobile": "large",
-        "rounded_corners": "large",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/search.json
+++ b/templates/search.json
@@ -41,12 +41,10 @@
         "item_674098"
       ],
       "settings": {
-        "borders": "full",
         "collection": "all-products",
         "color_scheme": "set-1",
         "full_width": false,
         "grid": "three",
-        "image_fit": "cover",
         "limit": 18,
         "message": "",
         "mobile_toggler": "MENU",
@@ -54,8 +52,6 @@
         "padding_bottom_mobile": "small",
         "padding_top": "medium",
         "padding_top_mobile": "small",
-        "rounded_corners": "small",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "sticky_sidebar": true,

--- a/templates/sunset/index.json
+++ b/templates/sunset/index.json
@@ -199,18 +199,14 @@
         "product_123449"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "none",
         "padding_bottom_mobile": "none",
         "padding_top": "none",
         "padding_top_mobile": "none",
-        "rounded_corners": "none",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "",

--- a/templates/tough/index.json
+++ b/templates/tough/index.json
@@ -191,18 +191,14 @@
         "product_109849"
       ],
       "settings": {
-        "borders": "image",
         "button_outline_label": "SEE ALL PRODUCTS",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-1",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "large",
         "padding_top": "medium",
         "padding_top_mobile": "large",
-        "rounded_corners": "large",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",

--- a/templates/vice/index.json
+++ b/templates/vice/index.json
@@ -144,18 +144,14 @@
         "product_123751"
       ],
       "settings": {
-        "borders": "full",
         "button_outline_label": "See all products",
         "button_outline_url": "booqable://products/",
         "color_scheme": "set-5",
         "image": "",
-        "image_fit": "cover",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",
         "padding_top_mobile": "medium",
-        "rounded_corners": "small",
-        "show_excerpt": false,
         "show_navigation": true,
         "show_pagination": true,
         "tag": "THIS WEEK",


### PR DESCRIPTION
This PR's goal is to move all the settings related to product card to the Global settings of theme and add a color scheme option there to satisfy all customer color needs

Initial issue https://github.com/booqable/horton-theme/pull/76

Media:

![Screenshot 2024-11-18 at 23 31 48](https://github.com/user-attachments/assets/5d9f7b78-329c-4ed0-bc24-192b1d1a2368)
![Screenshot 2024-11-18 at 23 32 55](https://github.com/user-attachments/assets/460c1fd8-949f-4f59-a14b-4dc029b9f3c7)

