### PR TITLE
Adjust the Weglot app icon positioning if the top bar is taller than the header

### DIFF
--- a/assets/footer.css
+++ b/assets/footer.css
@@ -196,6 +196,7 @@
 }
 
 #section-footer .footer__app .weglot-widget__item {
+  white-space: nowrap;
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 

--- a/assets/header.css
+++ b/assets/header.css
@@ -564,14 +564,13 @@ body:has(#mobile-menu-opener:checked) .header:has(~ #main section:first-child > 
     display: block;
     position: absolute;
     right: calc(var(--horizontal-padding) - 10px);
-    bottom: 50%;
+    bottom: calc(50% + 1px);
     transform: translate(100%, 50%);
     z-index: 1;
   }
 
   .header:not(.header-transparent):has(.top-bar__wrapper) .header__app {
-    bottom: calc(50% - var(--top-bar-height));
-    transform: translate(100%, 0);
+    bottom: calc((var(--header-height) - var(--top-bar-height)) / 2 + 1px);
   }
 
   .header__buttons .header__app {
@@ -580,6 +579,7 @@ body:has(#mobile-menu-opener:checked) .header:has(~ #main section:first-child > 
 
   #section-header .header__app [data-short-names="true"] {
     width: auto;
+    height: auto;
   }
 
   #section-header .header__app .weglot-widget__wrapper {
@@ -663,6 +663,7 @@ body:has(#mobile-menu-opener:checked) .header:has(~ #main section:first-child > 
   }
 
   #section-header .header__app .weglot-widget__item {
+    white-space: nowrap;
     transition: all var(--animation-duration) var(--transition-function-ease-in-out);
     color: var(--color-primary);
   }

--- a/assets/header.css
+++ b/assets/header.css
@@ -486,6 +486,7 @@ body:has(#mobile-menu-opener:checked) .header:has(~ #main section:first-child > 
 }
 
 #section-header .app-mobile .weglot-widget__item {
+  white-space: nowrap;
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 

--- a/sections/top-bar.liquid
+++ b/sections/top-bar.liquid
@@ -60,9 +60,9 @@
   >
     <div class="top-bar__container container">
       <div class="top-bar__info">
-        {%- render 'icon', icon: icon, style: icon_style -%}
-
         {%- if bar_text != blank -%}
+          {%- render 'icon', icon: icon, style: icon_style -%}
+
           <span class="top-bar__text top-bar__message bq-content rx-content">
             {{- bar_text -}}
           </span>


### PR DESCRIPTION
The PR's purpose is to align the Weglot app icon alongside with other icons in the header and make inside text in 1 row

Before:
![image](https://github.com/user-attachments/assets/36a2548c-627d-4bc0-9093-0ae3e4ff1c38)


After:
![Arc 2024-12-30 14 30 06](https://github.com/user-attachments/assets/d0509462-477c-4c30-b781-e2abee15bde2)
