### PR TITLE
Enhance link styles for `contentEditor` for better visibility

### DIFF
--- a/assets/rx.css
+++ b/assets/rx.css
@@ -113,6 +113,13 @@
 
 .bq-content.rx-content a {
   cursor: pointer;
+  text-decoration: none;
+  color: var(--color-outline);
+}
+
+.bq-content.rx-content a:hover,
+.bq-content.rx-content a:focus {
+  color: var(--color-outline-hover);
 }
 
 .bq-content.rx-content h1,
@@ -145,7 +152,6 @@
   line-height: var(--line-height-sm);
 }
 
-.bq-content.rx-content a,
 .bq-content.rx-content h1 a,
 .bq-content.rx-content h2 a,
 .bq-content.rx-content h3 a,
@@ -156,8 +162,6 @@
   color: var(--color-secondary);
 }
 
-.bq-content.rx-content a:hover,
-.bq-content.rx-content a:focus,
 .bq-content.rx-content h1 a:hover,
 .bq-content.rx-content h1 a:focus,
 .bq-content.rx-content h2 a:hover,

--- a/assets/rx.css
+++ b/assets/rx.css
@@ -113,13 +113,6 @@
 
 .bq-content.rx-content a {
   cursor: pointer;
-  text-decoration: none;
-  color: var(--color-outline);
-}
-
-.bq-content.rx-content a:hover,
-.bq-content.rx-content a:focus {
-  color: var(--color-outline-hover);
 }
 
 .bq-content.rx-content h1,
@@ -152,6 +145,7 @@
   line-height: var(--line-height-sm);
 }
 
+.bq-content.rx-content a,
 .bq-content.rx-content h1 a,
 .bq-content.rx-content h2 a,
 .bq-content.rx-content h3 a,
@@ -159,9 +153,11 @@
 .bq-content.rx-content h5 a,
 .bq-content.rx-content h6 a {
   text-decoration: none;
-  color: var(--color-secondary);
+  color: var(--color-outline);
 }
 
+.bq-content.rx-content a:hover,
+.bq-content.rx-content a:focus,
 .bq-content.rx-content h1 a:hover,
 .bq-content.rx-content h1 a:focus,
 .bq-content.rx-content h2 a:hover,
@@ -174,7 +170,7 @@
 .bq-content.rx-content h5 a:focus,
 .bq-content.rx-content h6 a:hover,
 .bq-content.rx-content h6 a:focus {
-  color: var(--color-secondary-hover);
+  color: var(--color-outline-hover);
 }
 
 .bq-content.rx-content ul,


### PR DESCRIPTION
When the links are added through "Text" element, it is impossible to differentiate them from the rest of the text. It is the same color, and it's not possible to change that.

In Editor, the links are blue, but on the actual website, they are the same color as the rest of the text.
<img width="308" alt="Screenshot 2024-12-30 at 11 48 39" src="https://github.com/user-attachments/assets/bf167fd0-2d01-46a4-ad1f-357b675a6e53" />


Therefore, this PR aims to fix inconsistencies in colors.

Before:

![Arc 2024-12-30 15 37 00](https://github.com/user-attachments/assets/cc3082c1-0420-4781-b685-8907235b4504)


After:

![Arc 2024-12-30 15 36 27](https://github.com/user-attachments/assets/9807676a-135c-4ec6-ba4a-15f68430b498)
