### PR TITLE
Add margin-bottom reset for the last heading elements in WYSIWYG editor

### DIFF
--- a/assets/rx.css
+++ b/assets/rx.css
@@ -130,6 +130,12 @@
   color: var(--color-primary);
 }
 
+.bq-content.rx-content h1:last-child,
+.bq-content.rx-content h2:last-child,
+.bq-content.rx-content h3:last-child {
+  margin-bottom: 0;
+}
+
 .bq-content.rx-content h1 {
   font-size: var(--font-size-h1);
   font-weight: var(--font-weight-h1);


### PR DESCRIPTION
When the content of the WYSiWYG field of a text section is a heading, and the padding bottom is set to none, it shows a white gap before the next section


![image](https://github.com/user-attachments/assets/986b9d65-4c1b-4307-878b-4e9bbf27929b)
![image (1)](https://github.com/user-attachments/assets/f2c1bc02-70f9-4c27-b3eb-a70ff4c7c681)
![image (2)](https://github.com/user-attachments/assets/7d05e0b8-49dd-4ea1-9ba9-e25d34890fcc)
