### PR TITLE
Adjust payments alignment in menu

### DIFF
--- a/assets/mega-menu.css
+++ b/assets/mega-menu.css
@@ -626,6 +626,7 @@
   }
 
   .menu__payments {
+    width: 100%;
     border-radius: var(--border-radius);
     padding: 16px 23px;
     margin: 60px 0 0;
@@ -635,6 +636,7 @@
 
   .menu__payments .payment {
     padding: 0;
+    justify-content: flex-end;
   }
 
   .menu__payments .payment span,


### PR DESCRIPTION
This pull request includes minor updates to improve the layout and alignment of the payment section in the menu.

Styling updates:

* Updated the `.menu__payments` class to set its width to 100%, ensuring it spans the full available space.
* Modified the `.menu__payments .payment` class to align its content to the end by adding `justify-content: flex-end`.


### Before:

![Arc 2025-05-08 18 59 54](https://github.com/user-attachments/assets/3c7aaae6-6b2e-40d6-b457-40751d02b0b9)


### After:

![Arc 2025-05-08 18 59 30](https://github.com/user-attachments/assets/3f2619ca-eab5-4f41-ae2f-9a5005176b14)
