### PR TITLE
Render placeholder when previewing App section

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -26,7 +26,7 @@
   align-items: center;
 }
 
-.spacer__preview span {
+.app__preview span {
   display: block;
   padding: 8px 12px;
   background-color: var(--background-primary);

--- a/assets/app.css
+++ b/assets/app.css
@@ -13,7 +13,7 @@
 
 .app__preview {
   height: 200px;
-  border-radius: var(--border-radius-block);
+  border-radius: var(--border-radius-rounded-blocks);
   background-image: repeating-linear-gradient(
     315deg,
     var(--background-primary),

--- a/assets/app.css
+++ b/assets/app.css
@@ -11,6 +11,28 @@
   padding-bottom: var(--padding-bottom-mobile, 0);
 }
 
+.app__preview {
+  height: 200px;
+  border-radius: var(--border-radius-block);
+  background-image: repeating-linear-gradient(
+    315deg,
+    var(--background-primary),
+    var(--background-primary) 6px,
+    var(--color-border) 6px,
+    var(--color-border) 7px
+  ) !important;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.spacer__preview span {
+  display: block;
+  padding: 8px 12px;
+  background-color: var(--background-primary);
+  color: var(--color-primary);
+}
+
 .app-desktop {
   display: none;
 }

--- a/sections/app.liquid
+++ b/sections/app.liquid
@@ -1,62 +1,65 @@
-{%- assign app = section.blocks | where: "type", "app" | first -%}
+{{ "app.css" | asset_url | stylesheet_tag }}
 
-{%- if app != blank -%}
-  {{ "app.css" | asset_url | stylesheet_tag }}
+{%- assign app                   = section.blocks | where: "type", "app" | first -%}
+{%- assign color_scheme          = section.settings.color_scheme -%}
+{%- assign padding_bottom        = section.settings.padding_bottom -%}
+{%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
+{%- assign padding_top           = section.settings.padding_top -%}
+{%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
 
-  {%- assign color_scheme          = section.settings.color_scheme -%}
-  {%- assign padding_bottom        = section.settings.padding_bottom -%}
-  {%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
-  {%- assign padding_top           = section.settings.padding_top -%}
-  {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
+{% comment %} CSS variables start {% endcomment %}
+{%- capture variables -%}
+  {%- case padding_top -%}
+    {%- when 'small' -%}
+      --padding-top: 40px;
+    {%- when 'medium' -%}
+      --padding-top: 80px;
+    {%- when 'large' -%}
+      --padding-top: 112px;
+  {%- endcase -%}
 
-  {% comment %} CSS variables start {% endcomment %}
-  {%- capture variables -%}
-    {%- case padding_top -%}
-      {%- when 'small' -%}
-        --padding-top: 40px;
-      {%- when 'medium' -%}
-        --padding-top: 80px;
-      {%- when 'large' -%}
-        --padding-top: 112px;
-    {%- endcase -%}
+  {%- case padding_bottom -%}
+    {%- when 'small' -%}
+      --padding-bottom: 40px;
+    {%- when 'medium' -%}
+      --padding-bottom: 80px;
+    {%- when 'large' -%}
+      --padding-bottom: 112px;
+  {%- endcase -%}
 
-    {%- case padding_bottom -%}
-      {%- when 'small' -%}
-        --padding-bottom: 40px;
-      {%- when 'medium' -%}
-        --padding-bottom: 80px;
-      {%- when 'large' -%}
-        --padding-bottom: 112px;
-    {%- endcase -%}
+  {%- case padding_top_mobile -%}
+    {%- when 'small' -%}
+      --padding-top-mobile: 24px;
+    {%- when 'medium' -%}
+      --padding-top-mobile: 40px;
+    {%- when 'large' -%}
+      --padding-top-mobile: 60px;
+  {%- endcase -%}
 
-    {%- case padding_top_mobile -%}
-      {%- when 'small' -%}
-        --padding-top-mobile: 24px;
-      {%- when 'medium' -%}
-        --padding-top-mobile: 40px;
-      {%- when 'large' -%}
-        --padding-top-mobile: 60px;
-    {%- endcase -%}
+  {%- case padding_bottom_mobile -%}
+    {%- when 'small' -%}
+      --padding-bottom-mobile: 24px;
+    {%- when 'medium' -%}
+      --padding-bottom-mobile: 40px;
+    {%- when 'large' -%}
+      --padding-bottom-mobile: 60px;
+  {%- endcase -%}
+{%- endcapture -%}
+{% comment %} CSS variables end {% endcomment %}
 
-    {%- case padding_bottom_mobile -%}
-      {%- when 'small' -%}
-        --padding-bottom-mobile: 24px;
-      {%- when 'medium' -%}
-        --padding-bottom-mobile: 40px;
-      {%- when 'large' -%}
-        --padding-bottom-mobile: 60px;
-    {%- endcase -%}
-  {%- endcapture -%}
-  {% comment %} CSS variables end {% endcomment %}
-
-  <div class="app__wrapper color-{{- color_scheme.id -}}{% if padding_top != blank or padding_top_mobile != blank %} app__wrapper--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} app__wrapper--padding-bottom{%- endif -%}" style="{{- variables | escape -}}">
-    <div class="app__container container">
+<div class="app__wrapper color-{{- color_scheme.id -}}{% if padding_top != blank or padding_top_mobile != blank %} app__wrapper--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} app__wrapper--padding-bottom{%- endif -%}" style="{{- variables | escape -}}">
+  <div class="app__container container">
+    {%- unless section_preview -%}
       <div class="app__content">
         {% render 'app', block: app, section: section %}
       </div>
-    </div>
+    {%- else -%}
+      <div class="app__preview">
+        <span>The contents of this section vary by App.</span>
+      </div>
+    {%- endunless -%}
   </div>
-{%- endif -%}
+</div>
 
 {% schema %}
   {

--- a/sections/app.liquid
+++ b/sections/app.liquid
@@ -2,6 +2,7 @@
 
 {%- assign app                   = section.blocks | where: "type", "app" | first -%}
 {%- assign color_scheme          = section.settings.color_scheme -%}
+{%- assign rounded_corners       = section.settings.rounded_corners -%}
 {%- assign padding_bottom        = section.settings.padding_bottom -%}
 {%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
 {%- assign padding_top           = section.settings.padding_top -%}
@@ -44,6 +45,17 @@
     {%- when 'large' -%}
       --padding-bottom-mobile: 60px;
   {%- endcase -%}
+
+  {%- case rounded_corners -%}
+    {%- when 'none' -%}
+      --border-radius-rounded-blocks: 0px;
+    {%- when 'small' -%}
+      --border-radius-rounded-blocks: 8px;
+    {%- when 'medium' -%}
+      --border-radius-rounded-blocks: 16px;
+    {%- when 'large' -%}
+      --border-radius-rounded-blocks: 32px;
+  {%- endcase -%}
 {%- endcapture -%}
 {% comment %} CSS variables end {% endcomment %}
 
@@ -76,6 +88,30 @@
         "id": "color_scheme",
         "label": "Color scheme",
         "default": "set-1"
+      },
+      {
+        "type": "select",
+        "id": "rounded_corners",
+        "label": "Rounded corners",
+        "options": [
+          {
+            "value": "none",
+            "label": "None"
+          },
+          {
+            "value": "small",
+            "label": "Small"
+          },
+          {
+            "value": "medium",
+            "label": "Medium"
+          },
+          {
+            "value": "large",
+            "label": "Large"
+          }
+        ],
+        "default": "none"
       },
       {
         "type": "header",


### PR DESCRIPTION
This PR introduces changes to improve the styling and behavior of the app's preview section, as well as updates to the `app.liquid` template for better handling of section previews. The most significant changes include adding new CSS styles for the preview section and modifying the logic in the liquid template to display a preview when in section preview mode.

### Styling changes:

* [`assets/app.css`](diffhunk://#diff-0cdd3400a6c98881ff1071940718d3eb6c0df60ea25effaee1d0f749ac0c4bd0R14-R35): Added a new `.app__preview` class to style the preview section with a height of 200px, border-radius, and a repeating linear gradient background. Also added `.spacer__preview span` for styling preview text with padding and color adjustments.

### Template logic updates:

* [`sections/app.liquid`](diffhunk://#diff-a81caf6cda2f8208ab5615d53feeb90942792cb5e77288a640fb73ef9c02e72cR52-L59): Updated the liquid template to include conditional logic for displaying a preview section (`.app__preview`) when in section preview mode. This includes a placeholder message indicating that the contents vary by app.
* [`sections/app.liquid`](diffhunk://#diff-a81caf6cda2f8208ab5615d53feeb90942792cb5e77288a640fb73ef9c02e72cL1-R3): Adjusted the formatting of variable assignments for better readability and consistency.