### PR TITLE
Footer: Fix liquid syntax error in default installation

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -287,7 +287,7 @@
         "type": "text",
         "id": "bottom_text",
         "label": "Bottom message",
-        "default": "{{ \"now\" | date: \"%Y\" }} {{ shop.name }}. All right reserved.",
+        "default": "{{ 'now' | date: '%Y' }} {{ shop.name }}. All right reserved.",
         "info": "This template keeps the year auto-updated and returns the name of your company. Leave blank to hide the text"
       },
       {


### PR DESCRIPTION
This PR fixes the Liquid error due to `strict mode`, like [here](https://github.com/booqable/horton-theme/pull/104)