### PR TITLE
Fit logo into the parent element

### DIFF
--- a/assets/header.css
+++ b/assets/header.css
@@ -427,6 +427,11 @@ body:has(#mobile-menu-opener:checked) .header:has(~ #main section:first-child > 
     grid-template-columns: 230px 1fr 230px;
   }
 
+  .header__logo,
+  .header__logo-image {
+    max-width: 100%;
+  }
+
   .header__date-picker-wrapper {
     position: static;
     width: auto;

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -116,8 +116,7 @@
         {%- render 'image',
             image: logo_transparent,
             class: 'header__logo-image',
-            custom_width: '170',
-            custom_size: '170px',
+            size: 'logo',
             custom_alt: shop.name,
             keep_type: true
         -%}


### PR DESCRIPTION
The purpose of this PR is to fix the size of header logo on page scroll, and style the logo to ensure it fits the parent and displays at the correct size if the image is too large and extends beyond the parent element

[The issue](https://www.loom.com/share/d0652bc693bd42d6a6399a217459d075?sid=e952b016-573d-4f63-ba6e-9d49b7ec6d92)

### Before:

<img width="1009" height="153" alt="Arc 2025-08-18 13 06 07" src="https://github.com/user-attachments/assets/80350026-9d4a-4383-bfd1-a4e83f6652fb" />
<img width="1009" height="72" alt="Arc 2025-08-18 13 06 30" src="https://github.com/user-attachments/assets/f2ac5a20-8cf5-4108-a417-b7e29d637d66" />



### After:

<img width="1007" height="73" alt="Arc 2025-08-18 13 07 05" src="https://github.com/user-attachments/assets/2b3cfdd7-80b0-40a9-b18d-62791b5cef60" />
<img width="1009" height="137" alt="Arc 2025-08-18 13 06 54" src="https://github.com/user-attachments/assets/35156a25-e230-4f28-9773-01bd1ab3caac" />
