### PR TITLE
Fix the background height of the Call to action section

### DIFF
--- a/assets/call-to-action.css
+++ b/assets/call-to-action.css
@@ -77,6 +77,10 @@
   margin: 0 auto 40px;
 }
 
+.cta__image-wrapper {
+  height: 100%;
+}
+
 @media (min-width: 992px) {
   .cta__wrapper {
     min-height: var(--min-height);


### PR DESCRIPTION
This PR aims to fix the background height to fit its parent element


### Before:
<img width="1309" height="823" alt="Arc 2025-09-08 15 52 38" src="https://github.com/user-attachments/assets/0931033b-4c52-439d-a8ae-d616c13ecb51" />
<img width="374" height="543" alt="Arc 2025-09-08 15 53 08" src="https://github.com/user-attachments/assets/b5940713-c25e-49a7-b661-8fcacb37dac1" />



### After:
<img width="1311" height="823" alt="Arc 2025-09-08 15 51 42" src="https://github.com/user-attachments/assets/24b5de87-a1b5-4c2e-b866-de53142e6c14" />

<img width="371" height="544" alt="Arc 2025-09-08 15 53 41" src="https://github.com/user-attachments/assets/a5d308d1-54ab-4223-b784-beca2f4bde64" />
