### PR TITLE
Fix very large size of collection images

### DIFF
--- a/sections/collections.liquid
+++ b/sections/collections.liquid
@@ -124,7 +124,8 @@
             placeholder: image_placeholder,
             settings: settings,
             counter_singular: counter_singular,
-            counter_plural: counter_plural
+            counter_plural: counter_plural,
+            image_ratio: false
         -%}
     {%- unless full_width -%}
       </div>

--- a/sections/list-collections.liquid
+++ b/sections/list-collections.liquid
@@ -127,7 +127,8 @@
               placeholder: image_placeholder,
               settings: settings,
               counter_singular: counter_singular,
-              counter_plural: counter_plural
+              counter_plural: counter_plural,
+              image_ratio: false
           -%}
 
           {%- if full_width -%}

--- a/snippets/collections-grid.liquid
+++ b/snippets/collections-grid.liquid
@@ -8,7 +8,8 @@
   show_amount - boolean optional,
   show_arrow - boolean optional,
   placeholder - image optional,
-  counter_label - "string" optional
+  counter_label - "string" optional,
+  image_ratio - boolean optional
 
   Usage:
 
@@ -20,7 +21,8 @@
       placeholder: your_id,
       settings: settings,
       counter_singular: your_id,
-      counter_plural: your_id
+      counter_plural: your_id,
+      image_ratio: your_id
   -%}
 
 {% endcomment %}
@@ -73,7 +75,8 @@
           image: image,
           image_alt: name,
           image_class: 'collections__image',
-          image_size: 'm'
+          image_size: 'm',
+          use_ratio: image_ratio
         -%}
       </span>
 


### PR DESCRIPTION
The issue here https://booqable.slack.com/archives/C08HDRSEA67/p1757675674040939

Before:
<img width="1362" height="1267" alt="Arc 2025-09-12 17 43 18" src="https://github.com/user-attachments/assets/d6bb40e2-7974-48fa-aede-da1f14ece383" />



After:
<img width="1404" height="992" alt="Arc 2025-09-12 17 42 37" src="https://github.com/user-attachments/assets/785e30dc-d1a9-402d-b5ce-a08a3c55d208" />
