### PR TITLE
Update `alt` attribute assignment for collection images

### DIFF
--- a/snippets/collections-grid.liquid
+++ b/snippets/collections-grid.liquid
@@ -53,6 +53,7 @@
     {%- assign url = "" -%}
     {%- assign name = "" -%}
     {%- assign image = "" -%}
+    {%- assign alt = "" -%}
 
     {%- if collection != blank -%}
       {%- assign url = collection.url -%}
@@ -62,8 +63,10 @@
 
       {%- if collection.image -%}
         {%- assign image = collection.image -%}
+        {%- assign alt   = name -%}
       {%- elsif first_product and first_product.images.first != empty -%}
         {%- assign image = first_product.images.first -%}
+        {%- assign alt   = first_product.name -%}
       {%- endif -%}
     {%- else -%}
       {%- assign image = placeholder -%}
@@ -73,7 +76,7 @@
       <span class="collections__image-item">
         {%- render 'image',
           image: image,
-          image_alt: name,
+          image_alt: alt,
           image_class: 'collections__image',
           image_size: 'm',
           use_ratio: image_ratio


### PR DESCRIPTION
This PR aims to improve the accessibility and context of collection images by providing more descriptive alternative text. The main focus is on ensuring that the image alt attribute is set dynamically based on the collection displayed image in each collection. 

https://github.com/booqable/chameleon-theme/pull/343