### PR TITLE
Fix carousel goes beyond screen edges

### DIFF
--- a/assets/carousel.css
+++ b/assets/carousel.css
@@ -1,14 +1,15 @@
 .carousel {
   height: 100%;
-  width: calc(100% + 2 * var(--horizontal-padding));
-  margin: 0 calc(-1 * var(--horizontal-padding));
+  width: calc(100% + 2 * var(--horizontal-padding-mobile));
+  margin: 0 calc(-1 * var(--horizontal-padding-mobile));
+  padding: 12px 0 0;
   position: relative;
   contain: content; /* Performance: Reduces the scope of layout recalculations */
 }
 
 .carousel__wrapper {
   height: 100%;
-  padding: 0 var(--horizontal-padding);
+  padding: 0 var(--horizontal-padding-mobile);
   display: flex;
   gap: 16px;
   align-items: stretch;
@@ -39,7 +40,7 @@
   right: 0;
   bottom: 0;
   display: flex;
-  margin: 0 calc(var(--horizontal-padding) - 4px);
+  margin: 0 calc(var(--horizontal-padding-mobile) - 4px);
   z-index: 2;
 }
 
@@ -83,7 +84,7 @@
   position: absolute;
   left: 0;
   bottom: 0;
-  margin: 0 calc(var(--horizontal-padding) - 8px);
+  margin: 0 calc(var(--horizontal-padding-mobile) - 8px);
   display: flex;
   z-index: 2;
 }
@@ -127,9 +128,26 @@
 }
 
 @media (min-width: 992px) {
+  .carousel {
+    width: calc(100% + 2 * var(--horizontal-padding));
+    margin: 0 calc(-1 * var(--horizontal-padding));
+  }
+
+  .carousel__wrapper {
+    padding: 0 var(--horizontal-padding);
+  }
+
   .carousel__item {
     min-width: var(--slide-width);
     max-width: var(--slide-width);
+  }
+
+  .carousel__navigation {
+    margin: 0 calc(var(--horizontal-padding) - 8px);
+  }
+
+  .carousel__pagination {
+    margin: 0 calc(var(--horizontal-padding) - 4px);
   }
 }
 

--- a/assets/testimonials.css
+++ b/assets/testimonials.css
@@ -11,7 +11,7 @@
 }
 
 .testimonials__side {
-  margin: 0 0 50px;
+  margin: 0 0 38px;
 }
 
 .testimonials__bg-image-holder {
@@ -31,7 +31,6 @@
   flex-direction: column;
   align-items: flex-start;
   border-radius: var(--border-radius-rounded-blocks);
-  overflow: hidden;
   color: var(--color-accent);
   background: var(--background-accent);
 }
@@ -99,9 +98,6 @@
   background: var(--background-primary-hover);
 }
 
-.testimonials__side + .carousel .carousel__list {
-  padding: 12px 0;
-}
 
 @media (min-width: 992px) {
   .testimonials__wrapper--padding-top {
@@ -121,7 +117,7 @@
     flex: 0 0 calc(var(--title-max-width) + 32px);
     max-width: calc(var(--title-max-width) + 32px);
     padding: 0 32px 0 0;
-    margin: 12px 0;
+    margin: 12px 0 0;
     border-right: 1px solid var(--background-accent);
   }
 
@@ -175,13 +171,12 @@
   }
 
   .testimonials__side + .carousel .carousel__list {
-    overflow-x: scroll;
-    overflow-y: hidden;
+    overflow-x: clip;
   }
 
   .testimonials__side + .carousel .carousel__navigation {
     left: calc(-1 * var(--title-max-width) - var(--carousel-indent) * 2);
-    bottom: 12px;
+    bottom: 0;
     margin: 0;
   }
 }


### PR DESCRIPTION
This PR updates styling of the carousel component to improve responsiveness and visual alignment across some screen sizes. The main focus is to prevent the carousel goes beyond the screen edges on smaller breakpoints.

<img width="958" height="574" alt="Arc 2025-12-26 17 31 33" src="https://github.com/user-attachments/assets/35b59c82-a593-45cc-8ce9-17b43896e288" />
